### PR TITLE
docs(readme): add Common UI documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Join our [Discord server](https://discord.gg/FVQWsf5ENS) to connect with contrib
 
 ## Documentation
 
-Detailed technical documentation for this service is available on DeepWiki:
+[DeepWiki - Common-UI](https://deepwiki.com/PSMRI/Common-UI)
 
-- https://deepwiki.com/PSMRI/Common-UI
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # AMRIT - Common-UI
+[![DeepWiki](https://img.shields.io/badge/DeepWiki-PSMRI%2FCommon--UI-blue)](https://deepwiki.com/PSMRI/Common-UI)
+
 
 A configurable framework ccomprising reusable UI elements across multiple AMRIT service lines.
 
@@ -33,8 +35,5 @@ If you encounter any issues, bugs, or have feature requests, please file them in
 We’d love to have you join our community discussions and get real-time support!  
 Join our [Discord server](https://discord.gg/FVQWsf5ENS) to connect with contributors, ask questions, and stay updated. 
 
-## Documentation
-
-[DeepWiki - Common-UI](https://deepwiki.com/PSMRI/Common-UI)
 
 

--- a/README.md
+++ b/README.md
@@ -31,4 +31,11 @@ If you encounter any issues, bugs, or have feature requests, please file them in
 ## Join Our Community
 
 We’d love to have you join our community discussions and get real-time support!  
-Join our [Discord server](https://discord.gg/FVQWsf5ENS) to connect with contributors, ask questions, and stay updated.  
+Join our [Discord server](https://discord.gg/FVQWsf5ENS) to connect with contributors, ask questions, and stay updated. 
+
+## Documentation
+
+Detailed technical documentation for this service is available on DeepWiki:
+
+- https://deepwiki.com/PSMRI/Common-UI
+


### PR DESCRIPTION
Added DeepWiki UI documentation link as referenced by this repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a DeepWiki badge beneath the README title and applied minor formatting tweaks (extra blank lines) to the "Join Our Community" section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->