### PR TITLE
fix: resolve CSS build warning in abha-consent-form

### DIFF
--- a/src/registrar/abha-components/abha-consent-form/abha-consent-form.component.css
+++ b/src/registrar/abha-components/abha-consent-form/abha-consent-form.component.css
@@ -83,7 +83,7 @@
 .checkbox-container{
     display:flex;
     flex-direction: row;
-    align-items: start;
+    align-items: flex-start;
     font-size: small;
 }
 


### PR DESCRIPTION
## Summary

- Fixed CSS `align-items: start` → `flex-start` in abha-consent-form component
- Eliminates autoprefixer warning during Angular build

## Changes

- `src/registrar/abha-components/abha-consent-form/abha-consent-form.component.css` (line 86)
  - Before: `align-items: start;`
  - After: `align-items: flex-start;`

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

made as a part of https://github.com/PSMRI/MMU-UI/pull/336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated CSS checkbox styling to use standard flexbox keywords for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->