### PR TITLE
fix: improve accessibility for icon-only controls in ABHA components

### DIFF
--- a/src/registrar/abha-components/abha-consent-form/abha-consent-form.component.html
+++ b/src/registrar/abha-components/abha-consent-form/abha-consent-form.component.html
@@ -1,6 +1,8 @@
 <div class="title info">
     <h4>CONSENT FORM</h4>
-    <mat-icon class="pull-right close-btn md-24" matDialogClose (click)="closeDialog()" mat-icon-button>close</mat-icon>
+    <button mat-icon-button type="button" aria-label="Close dialog" class="pull-right close-btn md-24" matDialogClose (click)="closeDialog()">
+        <mat-icon>close</mat-icon>
+    </button>
 </div>
 <div mat-dialog-content>
     <form>

--- a/src/registrar/abha-components/abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component.html
+++ b/src/registrar/abha-components/abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component.html
@@ -1,6 +1,8 @@
 <div class="title info">
   <h4>{{ currentLanguageSet?.verifyMobileOtp }}</h4>
-  <mat-icon class="md-24 pull-right close-btn" matDialogClose (click)="closeDialog()" mat-icon-button>close</mat-icon>
+  <button mat-icon-button type="button" aria-label="Close dialog" class="md-24 pull-right close-btn" matDialogClose (click)="closeDialog()">
+    <mat-icon>close</mat-icon>
+  </button>
 </div>
 <br />
 

--- a/src/registrar/abha-components/abha-mobile-component/abha-mobile-component.component.html
+++ b/src/registrar/abha-components/abha-mobile-component/abha-mobile-component.component.html
@@ -1,6 +1,8 @@
 <div class="title info">
     <h4>{{ currentLanguageSet?.generateABHA }}</h4>
-    <mat-icon class="md-24 pull-right close-btn" matDialogClose (click)="closeDialog()" mat-icon-button>close</mat-icon>
+    <button mat-icon-button type="button" aria-label="Close dialog" class="md-24 pull-right close-btn" matDialogClose (click)="closeDialog()">
+        <mat-icon>close</mat-icon>
+    </button>
 </div>
 <br />
 

--- a/src/registrar/abha-components/display-abha-card/display-abha-card.component.html
+++ b/src/registrar/abha-components/display-abha-card/display-abha-card.component.html
@@ -1,7 +1,8 @@
 <div class="title info">
     <h4 class="title"> {{ currentLanguageSet?.aBHACard}} </h4>
-    <mat-icon class="md-24 pull-right close-btn" style="margin-top: 12px;" matDialogClose (click)="closeDialog()"
-        mat-icon-button>close</mat-icon>
+    <button mat-icon-button type="button" aria-label="Close dialog" class="md-24 pull-right close-btn" style="margin-top: 12px;" matDialogClose (click)="closeDialog()">
+        <mat-icon>close</mat-icon>
+    </button>
 </div>
 <div class="overlay" *ngIf="showProgressBar">
     <div class="overlay-content">

--- a/src/registrar/abha-components/download-search-abha/download-search-abha.component.html
+++ b/src/registrar/abha-components/download-search-abha/download-search-abha.component.html
@@ -1,8 +1,8 @@
 <div class="title info">
   <h4>{{ currentLanguageSet.searchAndDownloadAbha }}</h4>
-  <button class="pull-right close-btn"
+  <button mat-icon-button type="button" aria-label="Close dialog" class="pull-right close-btn"
     style="border: unset !important;background-color: unset !important; color: white;" matDialogClose
-    (click)="closeDialogAuth()" mat-icon-button>
+    (click)="closeDialogAuth()">
     <mat-icon class="md-24">close</mat-icon>
   </button>
 </div>
@@ -64,10 +64,12 @@
               aria-label="Third part of Aadhaar number" aria-describedby="aadhaar-format-hint" />
           </mat-form-field>
 
-          <mat-icon class="eye-icon" (click)="toggleVisibility()"
+          <button mat-icon-button type="button" aria-label="Toggle password visibility" class="eye-icon" (click)="toggleVisibility()"
             style="width: 25px; margin-bottom: -5px; margin-left: 15px;">
-            {{ inputType === 'password' ? 'visibility_off' : 'visibility' }}
-          </mat-icon>
+            <mat-icon>
+              {{ inputType === 'password' ? 'visibility_off' : 'visibility' }}
+            </mat-icon>
+          </button>
           <mat-error style="margin-top: -25px;" *ngIf="isInvalid"> Please enter a valid Aadhaar number</mat-error>
 
         </div>

--- a/src/registrar/abha-components/generate-abha-component/generate-abha-component.component.html
+++ b/src/registrar/abha-components/generate-abha-component/generate-abha-component.component.html
@@ -1,6 +1,8 @@
 <div class="title info">
   <h4>Generate ABHA CARD</h4>
-  <mat-icon class="pull-right close-btn md-24" matDialogClose (click)="closeDialog()" mat-icon-button>close</mat-icon>
+  <button mat-icon-button type="button" aria-label="Close dialog" class="pull-right close-btn md-24" matDialogClose (click)="closeDialog()">
+    <mat-icon>close</mat-icon>
+  </button>
 </div>
 <br />
 <div class="col-xs-12 col-sm-12" style="overflow: hidden;" [formGroup]="abhaGenerateForm">
@@ -41,9 +43,11 @@
             (keydown.backspace)="moveToPrev($event, part2)"  style="text-align: center;"/>
         </mat-form-field>
      
-        <mat-icon class="eye-icon" (click)="toggleVisibility()" style="width: 25px; margin-bottom: -5px;">
-          {{ inputType === 'password' ? 'visibility_off' : 'visibility' }}
-        </mat-icon>
+        <button mat-icon-button type="button" aria-label="Toggle password visibility" class="eye-icon" (click)="toggleVisibility()" style="width: 25px; margin-bottom: -5px;">
+          <mat-icon>
+            {{ inputType === 'password' ? 'visibility_off' : 'visibility' }}
+          </mat-icon>
+        </button>
         <mat-error style="margin-top: -25px;" *ngIf="isInvalid"> Please enter a valid Aadhaar number</mat-error>
         
       </div>


### PR DESCRIPTION
## 📝 Description

**Fixes #161**

This PR improves accessibility across multiple ABHA-related components in `Common-UI` by replacing non-interactive icon elements with properly accessible button controls and adding meaningful `aria-label` attributes throughout.

Icon-only interactive elements backed by `mat-icon` without a proper button wrapper are inaccessible to keyboard users and screen readers — they can't be focused, triggered via keyboard, or meaningfully announced. This PR addresses that pattern consistently across all affected ABHA components, aligning them with Angular Material accessibility best practices.

**Changes Made:**
- Replaced directly clickable `mat-icon` elements with accessible `button mat-icon-button` controls
- Added meaningful `aria-label` attributes to all icon-only interactive controls
- Improved keyboard navigation and screen-reader support for dialog and visibility actions
- Aligned components with Angular Material accessibility standards

**Components Updated:**
- `generate-abha-component`
- `download-search-abha`
- `display-abha-card`
- `abha-mobile-component`
- `abha-enter-mobile-otp-component`
- `abha-consent-form`


## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] 🎨 **UI/UX** (changes that affect the user interface)


## ℹ️ Additional Information

**Verification:**
- Verified only intended ABHA component templates were modified
- Ensured no unrelated formatting or structural changes were introduced
- Confirmed accessibility improvements follow Angular Material button interaction patterns
- Changes are strictly limited to Angular template HTML no TypeScript logic was modified

**Scope:** Template-only changes across 6 ABHA components. No functional behavior, business logic, or styling changes introduced.