### PR TITLE
fix: add missing aria-labels to icon-only controls in ABHA components

### DIFF
--- a/src/registrar/abha-components/abha-consent-form/abha-consent-form.component.html
+++ b/src/registrar/abha-components/abha-consent-form/abha-consent-form.component.html
@@ -1,6 +1,6 @@
 <div class="title info">
     <h4>CONSENT FORM</h4>
-    <mat-icon class="pull-right close-btn md-24" matDialogClose (click)="closeDialog()" mat-icon-button>close</mat-icon>
+    <mat-icon class="pull-right close-btn md-24" matDialogClose (click)="closeDialog()" mat-icon-button aria-label="Close dialog">close</mat-icon>
 </div>
 <div mat-dialog-content>
     <form>

--- a/src/registrar/abha-components/abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component.html
+++ b/src/registrar/abha-components/abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component.html
@@ -1,6 +1,6 @@
 <div class="title info">
   <h4>{{ currentLanguageSet?.verifyMobileOtp }}</h4>
-  <mat-icon class="md-24 pull-right close-btn" matDialogClose (click)="closeDialog()" mat-icon-button>close</mat-icon>
+  <mat-icon class="md-24 pull-right close-btn" matDialogClose (click)="closeDialog()" mat-icon-button aria-label="Close dialog">close</mat-icon>
 </div>
 <br />
 

--- a/src/registrar/abha-components/abha-mobile-component/abha-mobile-component.component.html
+++ b/src/registrar/abha-components/abha-mobile-component/abha-mobile-component.component.html
@@ -1,6 +1,6 @@
 <div class="title info">
     <h4>{{ currentLanguageSet?.generateABHA }}</h4>
-    <mat-icon class="md-24 pull-right close-btn" matDialogClose (click)="closeDialog()" mat-icon-button>close</mat-icon>
+    <mat-icon class="md-24 pull-right close-btn" matDialogClose (click)="closeDialog()" mat-icon-button aria-label="Close dialog">close</mat-icon>
 </div>
 <br />
 

--- a/src/registrar/abha-components/biometric-authentication/biometric-authentication.component.html
+++ b/src/registrar/abha-components/biometric-authentication/biometric-authentication.component.html
@@ -4,7 +4,8 @@
     class="pull-right close-btn md-24"
     matDialogClose
     (click)="closeDialog()"
-    mat-icon-button>
+    mat-icon-button
+    aria-label="Close dialog">
     close</mat-icon>
 </div>
 <div class="col-xs-12 col-sm-12" style="overflow: hidden;">

--- a/src/registrar/abha-components/display-abha-card/display-abha-card.component.html
+++ b/src/registrar/abha-components/display-abha-card/display-abha-card.component.html
@@ -1,7 +1,7 @@
 <div class="title info">
     <h4 class="title"> {{ currentLanguageSet?.aBHACard}} </h4>
     <mat-icon class="md-24 pull-right close-btn" style="margin-top: 12px;" matDialogClose (click)="closeDialog()"
-        mat-icon-button>close</mat-icon>
+        mat-icon-button aria-label="Close dialog">close</mat-icon>
 </div>
 <div class="overlay" *ngIf="showProgressBar">
     <div class="overlay-content">

--- a/src/registrar/abha-components/download-search-abha/download-search-abha.component.html
+++ b/src/registrar/abha-components/download-search-abha/download-search-abha.component.html
@@ -65,7 +65,7 @@
           </mat-form-field>
 
           <mat-icon class="eye-icon" (click)="toggleVisibility()"
-            style="width: 25px; margin-bottom: -5px; margin-left: 15px;">
+            style="width: 25px; margin-bottom: -5px; margin-left: 15px;" mat-icon-button aria-label="Toggle password visibility">
             {{ inputType === 'password' ? 'visibility_off' : 'visibility' }}
           </mat-icon>
           <mat-error style="margin-top: -25px;" *ngIf="isInvalid"> Please enter a valid Aadhaar number</mat-error>

--- a/src/registrar/abha-components/generate-abha-component/generate-abha-component.component.html
+++ b/src/registrar/abha-components/generate-abha-component/generate-abha-component.component.html
@@ -1,6 +1,6 @@
 <div class="title info">
   <h4>Generate ABHA CARD</h4>
-  <mat-icon class="pull-right close-btn md-24" matDialogClose (click)="closeDialog()" mat-icon-button>close</mat-icon>
+  <mat-icon class="pull-right close-btn md-24" matDialogClose (click)="closeDialog()" mat-icon-button aria-label="Close dialog">close</mat-icon>
 </div>
 <br />
 <div class="col-xs-12 col-sm-12" style="overflow: hidden;" [formGroup]="abhaGenerateForm">
@@ -41,7 +41,7 @@
             (keydown.backspace)="moveToPrev($event, part2)"  style="text-align: center;"/>
         </mat-form-field>
      
-        <mat-icon class="eye-icon" (click)="toggleVisibility()" style="width: 25px; margin-bottom: -5px;">
+        <mat-icon class="eye-icon" (click)="toggleVisibility()" style="width: 25px; margin-bottom: -5px;" mat-icon-button aria-label="Toggle password visibility">
           {{ inputType === 'password' ? 'visibility_off' : 'visibility' }}
         </mat-icon>
         <mat-error style="margin-top: -25px;" *ngIf="isInvalid"> Please enter a valid Aadhaar number</mat-error>

--- a/src/registrar/abha-components/health-id-display-modal/health-id-display-modal.component.html
+++ b/src/registrar/abha-components/health-id-display-modal/health-id-display-modal.component.html
@@ -19,6 +19,7 @@
       matDialogClose
       (click)="closeDialog()"
       mat-icon-button
+      aria-label="Close dialog"
     >
       <mat-icon>close</mat-icon>
     </button>


### PR DESCRIPTION
## 📋 Description
Fixes accessibility violations in ABHA components of Common-UI.
Adds missing aria-labels to all icon-only interactive controls.

Fixes: PSMRI/AMRIT#161

## ✅ Type of Change
- [x] 🐞 Bug fix
- [x] 🎨 UI/UX

## ℹ️ Additional Information
Changes:
- 7 close dialog buttons: added aria-label="Close dialog"
- 2 password toggles: added aria-label="Toggle password visibility" + converted from plain mat-icon to proper mat-icon-button
- Total: 9 accessibility violations fixed across 8 files
- Improves WCAG compliance and screen reader support