### PR TITLE
feat(v2/ui): add ZardUI component library (Button, Dialog, Form, Input, Loader, Pagination, Table, Toast)

### DIFF
--- a/v2/public-api.ts
+++ b/v2/public-api.ts
@@ -1,1 +1,2 @@
 export * from './tracking';
+export * from './ui';

--- a/v2/ui/README.md
+++ b/v2/ui/README.md
@@ -1,0 +1,64 @@
+# AMRIT Common-UI — ZardUI Component Kit (`v2/ui`)
+
+A set of standalone, Tailwind-based UI primitives (ZardUI) shared across AMRIT
+front-ends. These components were ported from `Helpline104-UI-NEXT` as part of the
+Angular ZardUI migration.
+
+> **Note:** Common-UI is consumed as a git submodule. It has no `package.json` of its
+> own — the **host application** must provide every peer dependency listed below.
+> Imports inside `v2/ui` are all relative, so the kit is self-contained apart from
+> these external packages.
+
+## Components
+
+| Component   | Import                          | Notable deps                       |
+| ----------- | ------------------------------- | ---------------------------------- |
+| Button      | `Common-UI/v2/ui/button`        | `@ng-icons/*`, `cva`               |
+| Dialog      | `Common-UI/v2/ui/dialog`        | `@angular/cdk` (overlay/portal), `rxjs`, `@ng-icons/*` |
+| Form        | `Common-UI/v2/ui/form`          | `cva`                              |
+| Input       | `Common-UI/v2/ui/input`         | `@angular/forms`                   |
+| Loader      | `Common-UI/v2/ui/loader`        | `cva`                              |
+| Pagination  | `Common-UI/v2/ui/pagination`    | `@ng-icons/*`, Button              |
+| Table       | `Common-UI/v2/ui/table`         | `cva`                              |
+| Toast       | `Common-UI/v2/ui/toast`         | `ngx-sonner`                       |
+
+All components re-export through `Common-UI/v2/ui` (see `index.ts`) and are surfaced
+from the package root via `v2/public-api.ts`.
+
+## Required peer dependencies
+
+Install these in the **host application**. Versions below match the source repo
+(`Helpline104-UI-NEXT`) at the time of the port — keep the host within the same
+major to avoid API drift.
+
+| Package                     | Version    | Used by                                  |
+| --------------------------- | ---------- | ---------------------------------------- |
+| `@angular/core`             | `^20.3.0`  | all                                      |
+| `@angular/common`           | `^20.3.0`  | dialog, pagination (`NgTemplateOutlet`, `isPlatformBrowser`) |
+| `@angular/forms`            | `^20.3.0`  | input (`ControlValueAccessor`)           |
+| `@angular/cdk`              | `^20.2.14` | dialog (`overlay`, `portal`)             |
+| `@ng-icons/core`            | `^33.2.4`  | button, dialog, pagination               |
+| `@ng-icons/lucide`          | `^33.2.4`  | button, dialog, pagination               |
+| `class-variance-authority`  | `^0.7.1`   | all variant files (`cva`)                |
+| `clsx`                      | `^2.1.1`   | `utils/merge-classes`                    |
+| `tailwind-merge`            | `^3.6.0`   | `utils/merge-classes`                    |
+| `ngx-sonner`                | `^3.1.0`   | toast                                    |
+| `rxjs`                      | `~7.8.0`   | dialog (`dialog-ref`)                    |
+
+### Styling
+
+Components emit Tailwind utility classes (resolved at runtime through
+`twMerge` / `clsx`). The host app must have **Tailwind CSS v4** configured:
+
+| Package                  | Version     |
+| ------------------------ | ----------- |
+| `tailwindcss`            | `^4.3.0`    |
+| `@tailwindcss/postcss`   | `^4.3.0`    |
+| `tailwindcss-animate`    | `^1.0.7`    |
+
+Without Tailwind in the host build, the components render unstyled.
+
+## License
+
+Part of AMRIT. Licensed under the **GNU General Public License v3.0** — see the
+header in each source file and the repository `LICENSE`.

--- a/v2/ui/button/button.component.ts
+++ b/v2/ui/button/button.component.ts
@@ -1,0 +1,156 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  type OnDestroy,
+  ElementRef,
+  inject,
+  input,
+  signal,
+  ViewEncapsulation,
+  booleanAttribute,
+} from '@angular/core';
+
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideLoaderCircle } from '@ng-icons/lucide';
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import {
+  buttonVariants,
+  type ZardButtonShapeVariants,
+  type ZardButtonSizeVariants,
+  type ZardButtonTypeVariants,
+} from './button.variants';
+
+@Component({
+  selector: 'z-button, button[z-button], a[z-button]',
+  imports: [NgIcon],
+  template: `
+    @if (zLoading()) {
+      <ng-icon name="lucideLoaderCircle" class="animate-spin duration-2000" />
+    }
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  viewProviders: [provideIcons({ lucideLoaderCircle })],
+  host: {
+    '[class]': 'classes()',
+    '[attr.data-icon-only]': 'iconOnly() || null',
+    '[attr.data-disabled]': 'isNotInsideOfButtonOrLink() && zDisabled() || null',
+    '[attr.aria-disabled]': 'isNotInsideOfButtonOrLink() && zDisabled() || null',
+    '[attr.disabled]': 'isNotInsideOfButtonOrLink() && zDisabled() ? "" : null',
+    '[attr.role]': 'isNotInsideOfButtonOrLink() ? "button" : null',
+    '[attr.tabindex]': 'isNotInsideOfButtonOrLink() ? "0" : null',
+  },
+  exportAs: 'zButton',
+})
+export class ZardButtonComponent implements OnDestroy {
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+
+  readonly zType = input<ZardButtonTypeVariants>('default');
+  readonly zSize = input<ZardButtonSizeVariants>('default');
+  readonly zShape = input<ZardButtonShapeVariants>('default');
+  readonly class = input<ClassValue>('');
+  readonly zFull = input(false, { transform: booleanAttribute });
+  readonly zLoading = input(false, { transform: booleanAttribute });
+  readonly zDisabled = input(false, { transform: booleanAttribute });
+
+  private readonly iconOnlyState = signal(false);
+  readonly iconOnly = this.iconOnlyState.asReadonly();
+
+  private _mutationObserver: MutationObserver | null = null;
+
+  constructor() {
+    afterNextRender(() => {
+      if (typeof window === 'undefined' || typeof MutationObserver === 'undefined') {
+        return;
+      }
+
+      const check = () => {
+        const el = this.elementRef.nativeElement;
+        const hasIcon = el.querySelector('ng-icon') !== null;
+        const children = Array.from<Node>(el.childNodes);
+        const hasText = children.some(node => {
+          if (node.nodeType === 3) {
+            return node.textContent?.trim() !== '';
+          }
+          if (node.nodeType === 1) {
+            const element = node as HTMLElement;
+            if (element.matches('ng-icon')) {
+              return false;
+            }
+            return element.textContent?.trim() !== '';
+          }
+          return false;
+        });
+
+        this.iconOnlyState.set(hasIcon && !hasText);
+      };
+
+      check();
+      this._mutationObserver = new MutationObserver(check);
+      this._mutationObserver.observe(this.elementRef.nativeElement, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this._mutationObserver) {
+      this._mutationObserver.disconnect();
+      this._mutationObserver = null;
+    }
+  }
+
+  protected readonly classes = computed(() =>
+    mergeClasses(
+      buttonVariants({
+        zType: this.zType(),
+        zSize: this.zSize(),
+        zShape: this.zShape(),
+        zFull: this.zFull(),
+        zLoading: this.zLoading(),
+        zDisabled: this.zDisabled(),
+      }),
+      this.class(),
+    ),
+  );
+
+  protected readonly isNotInsideOfButtonOrLink = computed(() => {
+    // Evaluated once; assumes component parent doesn't change after mount
+    const zardButtonElement = this.elementRef.nativeElement;
+    if (zardButtonElement.parentElement) {
+      const { tagName } = zardButtonElement.parentElement;
+      return tagName !== 'BUTTON' && tagName !== 'A';
+    }
+    return true;
+  });
+}

--- a/v2/ui/button/button.variants.ts
+++ b/v2/ui/button/button.variants.ts
@@ -1,0 +1,84 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+export const buttonVariants = cva(
+  mergeClasses(
+    'focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+    'aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding',
+    "text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center",
+    'justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none',
+    'shrink-0 [&_svg]:shrink-0 outline-none group/button select-none [&_ng-icon]:flex [&_ng-icon]:items-center',
+  ),
+  {
+    variants: {
+      zType: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        destructive:
+          'bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30',
+        outline:
+          'border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+        ghost:
+          'hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      zSize: {
+        default: 'h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3',
+        icon: 'size-8',
+        'icon-xs':
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm': 'size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg',
+        'icon-lg': 'size-9',
+      },
+      zShape: {
+        default: 'rounded-md',
+        circle: 'rounded-full',
+        square: 'rounded-none',
+      },
+      zFull: {
+        true: 'w-full',
+      },
+      zLoading: {
+        true: 'pointer-events-none opacity-50',
+      },
+      zDisabled: {
+        true: 'pointer-events-none opacity-50',
+      },
+    },
+    defaultVariants: {
+      zType: 'default',
+      zSize: 'default',
+      zShape: 'default',
+    },
+  },
+);
+export type ZardButtonShapeVariants = NonNullable<VariantProps<typeof buttonVariants>['zShape']>;
+export type ZardButtonSizeVariants = NonNullable<VariantProps<typeof buttonVariants>['zSize']>;
+export type ZardButtonTypeVariants = NonNullable<VariantProps<typeof buttonVariants>['zType']>;

--- a/v2/ui/button/index.ts
+++ b/v2/ui/button/index.ts
@@ -1,0 +1,24 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './button.component';
+export * from './button.variants';

--- a/v2/ui/dialog/dialog-ref.ts
+++ b/v2/ui/dialog/dialog-ref.ts
@@ -1,0 +1,118 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import type { OverlayRef } from '@angular/cdk/overlay';
+import { isPlatformBrowser } from '@angular/common';
+import { EventEmitter, Inject, PLATFORM_ID } from '@angular/core';
+
+import { filter, fromEvent, Subject, takeUntil } from 'rxjs';
+
+import type { ZardDialogComponent, ZardDialogOptions } from './dialog.component';
+
+const enum eTriggerAction {
+  CANCEL = 'cancel',
+  OK = 'ok',
+}
+
+export class ZardDialogRef<T = any, R = any, U = any> {
+  private destroy$ = new Subject<void>();
+  private isClosing = false;
+  protected result?: R;
+  componentInstance: T | null = null;
+
+  constructor(
+    private overlayRef: OverlayRef,
+    private config: ZardDialogOptions<T, U>,
+    private containerInstance: ZardDialogComponent<T, U>,
+    @Inject(PLATFORM_ID) private platformId: object,
+  ) {
+    this.containerInstance.cancelTriggered.subscribe(() => this.trigger(eTriggerAction.CANCEL));
+    this.containerInstance.okTriggered.subscribe(() => this.trigger(eTriggerAction.OK));
+
+    if ((this.config.zMaskClosable ?? true) && isPlatformBrowser(this.platformId)) {
+      this.overlayRef
+        .outsidePointerEvents()
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(() => this.close());
+    }
+
+    if (isPlatformBrowser(this.platformId)) {
+      fromEvent<KeyboardEvent>(document, 'keydown')
+        .pipe(
+          filter(event => event.key === 'Escape'),
+          takeUntil(this.destroy$),
+        )
+        .subscribe(() => this.close());
+    }
+  }
+
+  close(result?: R) {
+    if (this.isClosing) {
+      return;
+    }
+
+    this.isClosing = true;
+    this.result = result;
+
+    if (isPlatformBrowser(this.platformId)) {
+      const hostElement = this.containerInstance.getNativeElement();
+      hostElement.classList.add('dialog-leave');
+    }
+
+    setTimeout(() => {
+      if (this.overlayRef) {
+        if (this.overlayRef.hasAttached()) {
+          this.overlayRef.detachBackdrop();
+        }
+        this.overlayRef.dispose();
+      }
+
+      if (!this.destroy$.closed) {
+        this.destroy$.next();
+        this.destroy$.complete();
+      }
+    }, 150);
+  }
+
+  private trigger(action: eTriggerAction) {
+    const trigger = { ok: this.config.zOnOk, cancel: this.config.zOnCancel }[action];
+
+    if (trigger instanceof EventEmitter) {
+      trigger.emit(this.getContentComponent());
+    } else if (typeof trigger === 'function') {
+      const result = trigger(this.getContentComponent()) as R;
+      this.closeWithResult(result);
+    } else {
+      this.close();
+    }
+  }
+
+  private getContentComponent(): T {
+    return this.componentInstance as T;
+  }
+
+  private closeWithResult(result: R): void {
+    if (result !== false) {
+      this.close(result);
+    }
+  }
+}

--- a/v2/ui/dialog/dialog.component.ts
+++ b/v2/ui/dialog/dialog.component.ts
@@ -1,0 +1,225 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { OverlayModule } from '@angular/cdk/overlay';
+import {
+  BasePortalOutlet,
+  CdkPortalOutlet,
+  type ComponentPortal,
+  PortalModule,
+  type TemplatePortal,
+} from '@angular/cdk/portal';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  type ComponentRef,
+  computed,
+  ElementRef,
+  type EmbeddedViewRef,
+  type EventEmitter,
+  inject,
+  output,
+  type TemplateRef,
+  type Type,
+  viewChild,
+  type ViewContainerRef,
+} from '@angular/core';
+
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideX } from '@ng-icons/lucide';
+
+import { mergeClasses, noopFn } from '../utils/merge-classes';
+
+import type { ZardDialogRef } from './dialog-ref';
+import { dialogVariants } from './dialog.variants';
+import { ZardButtonComponent } from '../button/button.component';
+
+export type OnClickCallback<T> = (instance: T) => false | void | object;
+export class ZardDialogOptions<T, U> {
+  zCancelIcon?: string;
+  zCancelText?: string | null;
+  zClosable?: boolean;
+  zContent?: string | TemplateRef<T> | Type<T>;
+  zCustomClasses?: string;
+  zData?: U;
+  zDescription?: string;
+  zHideFooter?: boolean;
+  zMaskClosable?: boolean;
+  zOkDestructive?: boolean;
+  zOkDisabled?: boolean;
+  zOkIcon?: string;
+  zOkText?: string | null;
+  zOnCancel?: EventEmitter<T> | OnClickCallback<T> = noopFn;
+  zOnOk?: EventEmitter<T> | OnClickCallback<T> = noopFn;
+  zTitle?: string | TemplateRef<T>;
+  zViewContainerRef?: ViewContainerRef;
+  zWidth?: string;
+}
+
+@Component({
+  selector: 'z-dialog',
+  imports: [OverlayModule, PortalModule, ZardButtonComponent, NgIcon],
+  template: `
+    @if (config.zClosable || config.zClosable === undefined) {
+      <button
+        type="button"
+        data-testid="z-close-header-button"
+        z-button
+        zType="ghost"
+        zSize="sm"
+        class="absolute top-1 right-1"
+        (click)="onCloseClick()"
+      >
+        <ng-icon name="lucideX" class="size-4!" />
+      </button>
+    }
+
+    @if (config.zTitle || config.zDescription) {
+      <header class="flex flex-col space-y-1.5 text-center sm:text-left">
+        @if (config.zTitle) {
+          <h4 data-testid="z-title" class="text-lg leading-none font-semibold tracking-tight">{{ config.zTitle }}</h4>
+
+          @if (config.zDescription) {
+            <p data-testid="z-description" class="text-muted-foreground text-sm">{{ config.zDescription }}</p>
+          }
+        }
+      </header>
+    }
+
+    <main class="flex flex-col space-y-4">
+      <ng-template cdkPortalOutlet />
+
+      @if (isStringContent) {
+        <div data-testid="z-content" [innerHTML]="config.zContent"></div>
+      }
+    </main>
+
+    @if (!config.zHideFooter) {
+      <footer class="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:gap-0 sm:space-x-2">
+        @if (config.zCancelText !== null) {
+          <button type="button" data-testid="z-cancel-button" z-button zType="outline" (click)="onCloseClick()">
+            @if (config.zCancelIcon) {
+              <ng-icon [svg]="config.zCancelIcon" class="size-4!" />
+            }
+
+            {{ config.zCancelText ?? 'Cancel' }}
+          </button>
+        }
+
+        @if (config.zOkText !== null) {
+          <button
+            type="button"
+            data-testid="z-ok-button"
+            z-button
+            [zType]="config.zOkDestructive ? 'destructive' : 'default'"
+            [zDisabled]="config.zOkDisabled"
+            (click)="onOkClick()"
+          >
+            @if (config.zOkIcon) {
+              <ng-icon [svg]="config.zOkIcon" class="size-4!" />
+            }
+
+            {{ config.zOkText ?? 'OK' }}
+          </button>
+        }
+      </footer>
+    }
+  `,
+  styles: `
+    :host {
+      opacity: 1;
+      transform: scale(1);
+      transition:
+        opacity 150ms ease-out,
+        transform 150ms ease-out;
+    }
+
+    @starting-style {
+      :host {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+
+    :host.dialog-leave {
+      opacity: 0;
+      transform: scale(0.9);
+      transition:
+        opacity 150ms ease-in,
+        transform 150ms ease-in;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  viewProviders: [provideIcons({ lucideX })],
+  host: {
+    '[class]': 'classes()',
+    '[style.width]': 'config.zWidth ? config.zWidth : null',
+    'animate.enter': 'dialog-enter',
+    'animate.leave': 'dialog-leave',
+  },
+  exportAs: 'zDialog',
+})
+export class ZardDialogComponent<T, U> extends BasePortalOutlet {
+  private readonly host = inject(ElementRef<HTMLElement>);
+  protected readonly config = inject(ZardDialogOptions<T, U>);
+
+  protected readonly classes = computed(() => mergeClasses(dialogVariants(), this.config.zCustomClasses));
+  dialogRef?: ZardDialogRef<T>;
+
+  protected readonly isStringContent = typeof this.config.zContent === 'string';
+
+  readonly portalOutlet = viewChild.required(CdkPortalOutlet);
+
+  okTriggered = output<void>();
+  cancelTriggered = output<void>();
+
+  constructor() {
+    super();
+  }
+
+  getNativeElement(): HTMLElement {
+    return this.host.nativeElement;
+  }
+
+  attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
+    if (this.portalOutlet()?.hasAttached()) {
+      throw new Error('Attempting to attach modal content after content is already attached');
+    }
+    return this.portalOutlet()?.attachComponentPortal(portal);
+  }
+
+  attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C> {
+    if (this.portalOutlet()?.hasAttached()) {
+      throw new Error('Attempting to attach modal content after content is already attached');
+    }
+
+    return this.portalOutlet()?.attachTemplatePortal(portal);
+  }
+
+  onOkClick() {
+    this.okTriggered.emit();
+  }
+
+  onCloseClick() {
+    this.cancelTriggered.emit();
+  }
+}

--- a/v2/ui/dialog/dialog.imports.ts
+++ b/v2/ui/dialog/dialog.imports.ts
@@ -1,0 +1,29 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { OverlayModule } from '@angular/cdk/overlay';
+import { PortalModule } from '@angular/cdk/portal';
+
+import { ZardButtonComponent } from '../button';
+import { ZardDialogComponent } from './dialog.component';
+
+export const ZardDialogImports = [ZardButtonComponent, ZardDialogComponent, OverlayModule, PortalModule] as const;

--- a/v2/ui/dialog/dialog.service.ts
+++ b/v2/ui/dialog/dialog.service.ts
@@ -1,0 +1,146 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { type ComponentType, Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
+import { ComponentPortal, TemplatePortal } from '@angular/cdk/portal';
+import { isPlatformBrowser } from '@angular/common';
+import {
+  inject,
+  Injectable,
+  InjectionToken,
+  Injector,
+  PLATFORM_ID,
+  TemplateRef,
+  type ViewContainerRef,
+} from '@angular/core';
+
+import { ZardDialogRef } from './dialog-ref';
+import { ZardDialogComponent, ZardDialogOptions } from './dialog.component';
+
+type ContentType<T> = ComponentType<T> | TemplateRef<T> | string;
+
+export const Z_MODAL_DATA = new InjectionToken<any>('Z_MODAL_DATA');
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ZardDialogService {
+  private overlay = inject(Overlay);
+  private injector = inject(Injector);
+  private platformId = inject(PLATFORM_ID);
+
+  create<T, U>(config: ZardDialogOptions<T, U>): ZardDialogRef<T> {
+    return this.open<T, U>(config.zContent as ComponentType<T>, config);
+  }
+
+  private open<T, U>(componentOrTemplateRef: ContentType<T>, config: ZardDialogOptions<T, U>) {
+    const overlayRef = this.createOverlay();
+
+    if (!overlayRef) {
+      return new ZardDialogRef(
+        undefined as unknown as OverlayRef,
+        config,
+        undefined as unknown as ZardDialogComponent<T, U>,
+        this.platformId,
+      );
+    }
+
+    const dialogContainer = this.attachDialogContainer<T, U>(overlayRef, config);
+    const dialogRef = this.attachDialogContent<T, U>(componentOrTemplateRef, dialogContainer, overlayRef, config);
+
+    dialogContainer.dialogRef = dialogRef;
+
+    return dialogRef;
+  }
+
+  private createOverlay(): OverlayRef | undefined {
+    if (isPlatformBrowser(this.platformId)) {
+      const overlayConfig = new OverlayConfig({
+        hasBackdrop: true,
+        positionStrategy: this.overlay.position().global(),
+      });
+
+      return this.overlay.create(overlayConfig);
+    }
+
+    return undefined;
+  }
+
+  private attachDialogContainer<T, U>(overlayRef: OverlayRef, config: ZardDialogOptions<T, U>) {
+    const injector = Injector.create({
+      parent: this.injector,
+      providers: [
+        { provide: OverlayRef, useValue: overlayRef },
+        { provide: ZardDialogOptions, useValue: config },
+      ],
+    });
+
+    const containerPortal = new ComponentPortal<ZardDialogComponent<T, U>>(
+      ZardDialogComponent,
+      config.zViewContainerRef,
+      injector,
+    );
+
+    const containerRef = overlayRef.attach<ZardDialogComponent<T, U>>(containerPortal);
+
+    return containerRef.instance;
+  }
+
+  private attachDialogContent<T, U>(
+    componentOrTemplateRef: ContentType<T>,
+    dialogContainer: ZardDialogComponent<T, U>,
+    overlayRef: OverlayRef,
+    config: ZardDialogOptions<T, U>,
+  ) {
+    const dialogRef = new ZardDialogRef<T>(overlayRef, config, dialogContainer, this.platformId);
+
+    if (componentOrTemplateRef instanceof TemplateRef) {
+      dialogContainer.attachTemplatePortal(
+        new TemplatePortal<T>(
+          componentOrTemplateRef,
+          null as unknown as ViewContainerRef,
+          {
+            dialogRef,
+          } as T,
+        ),
+      );
+    } else if (typeof componentOrTemplateRef !== 'string') {
+      const injector = this.createInjector<T, U>(dialogRef, config);
+      const contentRef = dialogContainer.attachComponentPortal<T>(
+        new ComponentPortal(componentOrTemplateRef, config.zViewContainerRef, injector),
+      );
+      dialogRef.componentInstance = contentRef.instance;
+    }
+
+    return dialogRef;
+  }
+
+  private createInjector<T, U>(dialogRef: ZardDialogRef<T>, config: ZardDialogOptions<T, U>) {
+    return Injector.create({
+      parent: this.injector,
+      providers: [
+        { provide: ZardDialogRef, useValue: dialogRef },
+        { provide: Z_MODAL_DATA, useValue: config.zData },
+      ],
+    });
+  }
+}

--- a/v2/ui/dialog/dialog.variants.ts
+++ b/v2/ui/dialog/dialog.variants.ts
@@ -1,0 +1,28 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const dialogVariants = cva(
+  'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg rounded-lg max-w-[calc(100%-2rem)]',
+);
+export type ZardDialogVariants = VariantProps<typeof dialogVariants>;

--- a/v2/ui/dialog/index.ts
+++ b/v2/ui/dialog/index.ts
@@ -1,0 +1,28 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export { ZardDialogComponent, ZardDialogOptions } from './dialog.component';
+export { type OnClickCallback as DialogOnClickCallback } from './dialog.component';
+export * from './dialog.service';
+export * from './dialog-ref';
+export * from './dialog.variants';
+export * from './dialog.imports';

--- a/v2/ui/form/form.component.ts
+++ b/v2/ui/form/form.component.ts
@@ -1,0 +1,125 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import type { ClassValue } from 'clsx';
+
+import {
+  formControlVariants,
+  formFieldVariants,
+  formLabelVariants,
+  formMessageVariants,
+  type ZardFormMessageTypeVariants,
+} from './form.variants';
+import { mergeClasses } from '../utils/merge-classes';
+
+@Component({
+  selector: 'z-form-field, [z-form-field]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zFormField',
+})
+export class ZardFormFieldComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(formFieldVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-form-control, [z-form-control]',
+  imports: [],
+  template: `
+    <div class="relative">
+      <ng-content />
+    </div>
+    @if (errorMessage() || helpText()) {
+      <div class="mt-1.5 min-h-5">
+        @if (errorMessage()) {
+          <p class="text-sm text-red-500">{{ errorMessage() }}</p>
+        } @else if (helpText()) {
+          <p class="text-muted-foreground text-sm">{{ helpText() }}</p>
+        }
+      </div>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zFormControl',
+})
+export class ZardFormControlComponent {
+  readonly class = input<ClassValue>('');
+  readonly errorMessage = input<string>('');
+  readonly helpText = input<string>('');
+
+  protected readonly classes = computed(() => mergeClasses(formControlVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-form-label, label[z-form-label]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zFormLabel',
+})
+export class ZardFormLabelComponent {
+  readonly class = input<ClassValue>('');
+  readonly zRequired = input(false, { transform: booleanAttribute });
+
+  protected readonly classes = computed(() =>
+    mergeClasses(formLabelVariants({ zRequired: this.zRequired() }), this.class()),
+  );
+}
+
+@Component({
+  selector: 'z-form-message, [z-form-message]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zFormMessage',
+})
+export class ZardFormMessageComponent {
+  readonly class = input<ClassValue>('');
+  readonly zType = input<ZardFormMessageTypeVariants>('default');
+
+  protected readonly classes = computed(() => mergeClasses(formMessageVariants({ zType: this.zType() }), this.class()));
+}

--- a/v2/ui/form/form.imports.ts
+++ b/v2/ui/form/form.imports.ts
@@ -1,0 +1,35 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ZardFormControlComponent,
+  ZardFormFieldComponent,
+  ZardFormLabelComponent,
+  ZardFormMessageComponent,
+} from './form.component';
+
+export const ZardFormImports = [
+  ZardFormFieldComponent,
+  ZardFormLabelComponent,
+  ZardFormControlComponent,
+  ZardFormMessageComponent,
+] as const;

--- a/v2/ui/form/form.variants.ts
+++ b/v2/ui/form/form.variants.ts
@@ -1,0 +1,54 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const formFieldVariants = cva('grid gap-2');
+
+export const formLabelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+  {
+    variants: {
+      zRequired: {
+        true: "after:content-['*'] after:ml-0.5 after:text-red-500",
+      },
+    },
+  },
+);
+
+export const formControlVariants = cva('');
+
+export const formMessageVariants = cva('text-sm', {
+  variants: {
+    zType: {
+      default: 'text-muted-foreground',
+      error: 'text-red-500',
+      success: 'text-green-500',
+      warning: 'text-yellow-500',
+    },
+  },
+  defaultVariants: {
+    zType: 'default',
+  },
+});
+
+export type ZardFormMessageTypeVariants = NonNullable<VariantProps<typeof formMessageVariants>['zType']>;

--- a/v2/ui/form/index.ts
+++ b/v2/ui/form/index.ts
@@ -1,0 +1,25 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './form.component';
+export * from './form.imports';
+export * from './form.variants';

--- a/v2/ui/index.ts
+++ b/v2/ui/index.ts
@@ -1,0 +1,30 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './button';
+export * from './dialog';
+export * from './form';
+export * from './input';
+export * from './loader';
+export * from './pagination';
+export * from './table';
+export * from './toast';

--- a/v2/ui/input/index.ts
+++ b/v2/ui/input/index.ts
@@ -1,0 +1,24 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './input.directive';
+export * from './input.variants';

--- a/v2/ui/input/input.directive.ts
+++ b/v2/ui/input/input.directive.ts
@@ -1,0 +1,177 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  computed,
+  Directive,
+  effect,
+  ElementRef,
+  forwardRef,
+  inject,
+  input,
+  linkedSignal,
+  model,
+} from '@angular/core';
+import { NG_VALUE_ACCESSOR, type ControlValueAccessor } from '@angular/forms';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses, noopFn } from '../utils/merge-classes';
+
+import {
+  inputVariants,
+  type ZardInputSizeVariants,
+  type ZardInputStatusVariants,
+  type ZardInputTypeVariants,
+} from './input.variants';
+
+type OnTouchedType = () => void;
+type ZardInputElement = HTMLInputElement | HTMLTextAreaElement;
+type ZardInputValue = string | number | null | undefined;
+type OnChangeType = (value: ZardInputValue) => void;
+
+@Directive({
+  selector: 'input[z-input], textarea[z-input]',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ZardInputDirective),
+      multi: true,
+    },
+  ],
+  host: {
+    '[class]': 'classes()',
+    '(input)': 'updateValue($event.target)',
+    '(blur)': 'onBlur()',
+  },
+  exportAs: 'zInput',
+})
+export class ZardInputDirective implements ControlValueAccessor {
+  private readonly elementRef = inject<ElementRef<ZardInputElement>>(ElementRef);
+  private onTouched: OnTouchedType = noopFn;
+  private onChangeFn: OnChangeType = noopFn;
+
+  readonly class = input<ClassValue>('');
+  readonly zBorderless = input(false, { transform: booleanAttribute });
+  readonly zSize = input<ZardInputSizeVariants>('default');
+  readonly zStatus = input<ZardInputStatusVariants>();
+  readonly value = model<ZardInputValue>(null);
+
+  readonly size = linkedSignal<ZardInputSizeVariants>(() => this.zSize());
+
+  protected readonly classes = computed(() =>
+    mergeClasses(
+      inputVariants({
+        zType: this.getType(),
+        zSize: this.size(),
+        zStatus: this.zStatus(),
+        zBorderless: this.zBorderless(),
+      }),
+      this.class(),
+    ),
+  );
+
+  constructor() {
+    effect(() => {
+      this.writeNativeValue(this.value());
+    });
+  }
+
+  disable(b: boolean): void {
+    this.elementRef.nativeElement.disabled = b;
+  }
+
+  setDataSlot(name: string): void {
+    if (this.elementRef?.nativeElement?.dataset) {
+      this.elementRef.nativeElement.dataset['slot'] = name;
+    }
+  }
+
+  protected updateValue(target: EventTarget | null): void {
+    const el = target as ZardInputElement | null;
+    this.value.set(this.readNativeValue(el));
+    this.onChangeFn(this.value());
+  }
+
+  protected onBlur() {
+    this.onTouched();
+  }
+
+  getType(): ZardInputTypeVariants {
+    const isTextarea = this.elementRef.nativeElement.tagName.toLowerCase() === 'textarea';
+    return isTextarea ? 'textarea' : 'default';
+  }
+
+  registerOnChange(fn: OnChangeType): void {
+    this.onChangeFn = fn;
+  }
+
+  registerOnTouched(fn: OnTouchedType): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disable(isDisabled);
+  }
+
+  writeValue(value: ZardInputValue): void {
+    const newValue = value ?? '';
+    this.value.set(newValue);
+  }
+
+  private isNumericInput(element: ZardInputElement): element is HTMLInputElement {
+    return element.tagName.toLowerCase() === 'input' && ['number', 'range'].includes(element.type);
+  }
+
+  private readNativeValue(element: ZardInputElement | null): ZardInputValue {
+    if (!element) {
+      return '';
+    }
+
+    if (this.isNumericInput(element)) {
+      const currentValue = this.value();
+
+      if (typeof currentValue === 'number' || currentValue === null) {
+        if (element.value === '') {
+          return null;
+        }
+
+        const numericValue = element.valueAsNumber;
+        return Number.isNaN(numericValue) ? null : numericValue;
+      }
+    }
+
+    return element.value;
+  }
+
+  private writeNativeValue(value: ZardInputValue): void {
+    const element = this.elementRef.nativeElement;
+
+    if (this.isNumericInput(element) && typeof value === 'number') {
+      element.value = Number.isNaN(value) ? '' : String(value);
+      return;
+    }
+
+    element.value = String(value ?? '');
+  }
+}

--- a/v2/ui/input/input.variants.ts
+++ b/v2/ui/input/input.variants.ts
@@ -1,0 +1,62 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export type zInputIcon = 'email' | 'password' | 'text';
+
+export const inputVariants = cva('w-full min-w-0', {
+  variants: {
+    zType: {
+      default:
+        'flex rounded-lg border border-input bg-transparent px-2.5 font-normal transition-colors file:inline-flex file:border-0 file:bg-transparent file:font-medium file:text-foreground placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30 dark:disabled:bg-input/80',
+      textarea:
+        'flex pb-2 min-h-20 h-auto rounded-lg border border-input bg-transparent px-3 py-2 text-base transition-colors placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30 dark:disabled:bg-input/80',
+    },
+    zSize: {
+      default: 'text-base md:text-sm',
+      sm: 'text-base md:text-sm',
+      lg: 'text-base',
+    },
+    zStatus: {
+      error: 'border-destructive focus-visible:ring-destructive',
+      warning: 'border-yellow-500 focus-visible:ring-yellow-500',
+      success: 'border-green-500 focus-visible:ring-green-500',
+    },
+    zBorderless: {
+      true: 'flex-1 bg-transparent border-0 outline-none focus-visible:ring-0 focus-visible:ring-offset-0 p-0',
+    },
+  },
+  defaultVariants: {
+    zType: 'default',
+    zSize: 'default',
+  },
+  compoundVariants: [
+    { zType: 'default', zSize: 'default', class: 'h-9 py-1 file:h-7 file:text-sm file:max-md:py-0' },
+    { zType: 'default', zSize: 'sm', class: 'h-8 py-1 file:h-6 file:text-sm file:max-md:py-1.5' },
+    { zType: 'default', zSize: 'lg', class: 'h-10 py-1 file:h-7 file:text-sm file:max-md:py-2.5' },
+  ],
+});
+
+export type ZardInputTypeVariants = NonNullable<VariantProps<typeof inputVariants>['zType']>;
+export type ZardInputSizeVariants = NonNullable<VariantProps<typeof inputVariants>['zSize']>;
+export type ZardInputStatusVariants = NonNullable<VariantProps<typeof inputVariants>['zStatus']>;

--- a/v2/ui/loader/index.ts
+++ b/v2/ui/loader/index.ts
@@ -1,0 +1,24 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './loader.component';
+export * from './loader.variants';

--- a/v2/ui/loader/loader.component.ts
+++ b/v2/ui/loader/loader.component.ts
@@ -1,0 +1,78 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import { loaderVariants, type ZardLoaderVariants } from './loader.variants';
+
+@Component({
+  selector: 'z-loader',
+  template: `
+    <div class="relative top-1/2 left-1/2 h-[inherit] w-[inherit]">
+      @for (_ of bars; track $index) {
+        <div
+          class="animate-spinner absolute -top-[3.9%] -left-[10%] h-[8%] w-[24%] rounded-md bg-black dark:bg-white"
+          [style]="{
+            animationDelay: animationDelay($index),
+            transform: transform($index),
+          }"
+        ></div>
+      }
+    </div>
+  `,
+  styles: `
+    @layer utilities {
+      @keyframes spinner {
+        0% {
+          opacity: 1;
+        }
+        100% {
+          opacity: 0.15;
+        }
+      }
+
+      .animate-spinner {
+        animation: spinner 1.2s linear infinite;
+      }
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zLoader',
+})
+export class ZardLoaderComponent {
+  readonly class = input<ClassValue>('');
+  readonly zSize = input<ZardLoaderVariants['zSize']>('default');
+
+  protected readonly bars = Array.from({ length: 12 });
+  protected readonly animationDelay = (index: number) => `-${1.3 - index * 0.1}s`;
+  protected readonly transform = (index: number) => `rotate(${30 * index}deg) translate(146%)`;
+
+  protected readonly classes = computed(() => mergeClasses(loaderVariants({ zSize: this.zSize() }), this.class()));
+}

--- a/v2/ui/loader/loader.variants.ts
+++ b/v2/ui/loader/loader.variants.ts
@@ -1,0 +1,37 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const loaderVariants = cva('', {
+  variants: {
+    zSize: {
+      default: 'size-6',
+      sm: 'size-4',
+      lg: 'size-8',
+    },
+  },
+  defaultVariants: {
+    zSize: 'default',
+  },
+});
+export type ZardLoaderVariants = VariantProps<typeof loaderVariants>;

--- a/v2/ui/pagination/index.ts
+++ b/v2/ui/pagination/index.ts
@@ -1,0 +1,25 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './pagination.component';
+export * from './pagination.imports';
+export * from './pagination.variants';

--- a/v2/ui/pagination/pagination.component.ts
+++ b/v2/ui/pagination/pagination.component.ts
@@ -1,0 +1,285 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { NgTemplateOutlet } from '@angular/common';
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  model,
+  output,
+  type TemplateRef,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronLeft, lucideChevronRight, lucideEllipsis } from '@ng-icons/lucide';
+import type { ClassValue } from 'clsx';
+
+import {
+  ZardButtonComponent,
+  type ZardButtonSizeVariants,
+  type ZardButtonTypeVariants,
+} from '../button';
+import {
+  paginationContentVariants,
+  paginationEllipsisVariants,
+  paginationNextVariants,
+  paginationPreviousVariants,
+  paginationVariants,
+} from './pagination.variants';
+import { mergeClasses } from '../utils/merge-classes';
+
+@Component({
+  selector: 'ul[z-pagination-content]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    'data-slot': 'pagination-content',
+    '[class]': 'classes()',
+  },
+  exportAs: 'zPaginationContent',
+})
+export class ZardPaginationContentComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(paginationContentVariants(), this.class()));
+}
+
+@Component({
+  selector: 'li[z-pagination-item]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    'data-slot': 'pagination-item',
+  },
+  exportAs: 'zPaginationItem',
+})
+export class ZardPaginationItemComponent {}
+// Structural wrapper component for pagination items (<li>). No inputs required.
+
+@Component({
+  selector: 'button[z-pagination-button], a[z-pagination-button]',
+  imports: [ZardButtonComponent],
+  template: `
+    <z-button
+      [attr.data-active]="zActive() || null"
+      [class]="class()"
+      [zDisabled]="zDisabled()"
+      [zSize]="zSize()"
+      [zType]="zType()"
+    >
+      <ng-content />
+    </z-button>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    'data-slot': 'pagination-button',
+  },
+  exportAs: 'zPaginationButton',
+})
+export class ZardPaginationButtonComponent {
+  readonly class = input<ClassValue>('');
+  readonly zActive = input(false, { transform: booleanAttribute });
+  readonly zDisabled = input(false, { transform: booleanAttribute });
+  readonly zSize = input<ZardButtonSizeVariants>('default');
+
+  protected readonly zType = computed<ZardButtonTypeVariants>(() => (this.zActive() ? 'outline' : 'ghost'));
+}
+
+@Component({
+  selector: 'z-pagination-previous',
+  imports: [ZardPaginationButtonComponent, NgIcon],
+  template: `
+    <button
+      type="button"
+      z-pagination-button
+      [attr.disabled]="zDisabled() ? '' : null"
+      [class]="classes()"
+      [zSize]="zSize()"
+      [zDisabled]="zDisabled()"
+    >
+      <span class="sr-only">To previous page</span>
+      <ng-icon name="lucideChevronLeft" aria-hidden="true" />
+      <span class="hidden sm:block" aria-hidden="true">Previous</span>
+    </button>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  viewProviders: [provideIcons({ lucideChevronLeft })],
+  exportAs: 'zPaginationPrevious',
+})
+export class ZardPaginationPreviousComponent {
+  readonly class = input<ClassValue>('');
+  readonly zDisabled = input(false, { transform: booleanAttribute });
+  readonly zSize = input<ZardButtonSizeVariants>('default');
+
+  protected readonly classes = computed(() => mergeClasses(paginationPreviousVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-pagination-next',
+  imports: [ZardPaginationButtonComponent, NgIcon],
+  template: `
+    <button
+      type="button"
+      z-pagination-button
+      [attr.disabled]="zDisabled() ? '' : null"
+      [class]="classes()"
+      [zDisabled]="zDisabled()"
+      [zSize]="zSize()"
+    >
+      <span class="sr-only">To next page</span>
+      <span class="hidden sm:block" aria-hidden="true">Next</span>
+      <ng-icon name="lucideChevronRight" aria-hidden="true" />
+    </button>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  viewProviders: [provideIcons({ lucideChevronRight })],
+  exportAs: 'zPaginationNext',
+})
+export class ZardPaginationNextComponent {
+  readonly class = input<ClassValue>('');
+  readonly zDisabled = input(false, { transform: booleanAttribute });
+  readonly zSize = input<ZardButtonSizeVariants>('default');
+
+  protected readonly classes = computed(() => mergeClasses(paginationNextVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-pagination-ellipsis',
+  imports: [NgIcon],
+  template: `
+    <ng-icon name="lucideEllipsis" aria-hidden="true" />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  viewProviders: [provideIcons({ lucideEllipsis })],
+  host: {
+    '[class]': 'classes()',
+    'aria-hidden': 'true',
+  },
+  exportAs: 'zPaginationEllipsis',
+})
+export class ZardPaginationEllipsisComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(paginationEllipsisVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-pagination',
+  imports: [
+    ZardPaginationContentComponent,
+    ZardPaginationItemComponent,
+    ZardPaginationButtonComponent,
+    ZardPaginationPreviousComponent,
+    ZardPaginationNextComponent,
+    NgTemplateOutlet,
+  ],
+  template: `
+    @if (zContent()) {
+      <ng-container *ngTemplateOutlet="zContent()" />
+    } @else {
+      <ul z-pagination-content>
+        <li z-pagination-item>
+          @let pagePrevious = Math.max(1, zPageIndex() - 1);
+          <z-pagination-previous
+            [zSize]="zSize()"
+            [zDisabled]="zDisabled() || zPageIndex() === 1"
+            (click)="goToPage(pagePrevious)"
+          />
+        </li>
+
+        @for (page of pages(); track page) {
+          <li z-pagination-item>
+            <button
+              z-pagination-button
+              type="button"
+              class="focus-visible:rounded-md"
+              [attr.aria-current]="page === zPageIndex() ? 'page' : null"
+              [attr.aria-disabled]="zDisabled() || null"
+              [zActive]="page === zPageIndex()"
+              [zDisabled]="zDisabled()"
+              [zSize]="zSize()"
+              (click)="goToPage(page)"
+            >
+              <span class="sr-only">{{ pages().length === page ? 'To last page, page' : 'To page' }}</span>
+              {{ page }}
+            </button>
+          </li>
+        }
+
+        <li z-pagination-item>
+          @let pageNext = Math.min(zPageIndex() + 1, zTotal());
+          <z-pagination-next
+            [zSize]="zSize()"
+            [zDisabled]="zDisabled() || zPageIndex() === zTotal()"
+            (click)="goToPage(pageNext)"
+          />
+        </li>
+      </ul>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    role: 'group',
+    '[attr.aria-label]': 'zAriaLabel()',
+    'data-slot': 'pagination',
+    '[class]': 'classes()',
+  },
+  exportAs: 'zPagination',
+})
+export class ZardPaginationComponent {
+  readonly zPageIndex = model<number>(1);
+  readonly zTotal = input<number>(1);
+  readonly zSize = input<ZardButtonSizeVariants>('default');
+  readonly zDisabled = input(false, { transform: booleanAttribute });
+  readonly zContent = input<TemplateRef<void> | undefined>();
+  readonly zAriaLabel = input('Pagination');
+
+  readonly class = input<ClassValue>('');
+
+  readonly zPageIndexChange = output<number>();
+  readonly Math = Math;
+
+  protected readonly classes = computed(() => mergeClasses(paginationVariants(), this.class()));
+  readonly pages = computed<number[]>(() => Array.from({ length: Math.max(0, this.zTotal()) }, (_, i) => i + 1));
+
+  goToPage(page: number): void {
+    if (!this.zDisabled() && page !== this.zPageIndex()) {
+      this.zPageIndex.set(page);
+      this.zPageIndexChange.emit(page);
+    }
+  }
+}

--- a/v2/ui/pagination/pagination.imports.ts
+++ b/v2/ui/pagination/pagination.imports.ts
@@ -1,0 +1,41 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ZardPaginationButtonComponent,
+  ZardPaginationComponent,
+  ZardPaginationContentComponent,
+  ZardPaginationEllipsisComponent,
+  ZardPaginationItemComponent,
+  ZardPaginationNextComponent,
+  ZardPaginationPreviousComponent,
+} from './pagination.component';
+
+export const ZardPaginationImports = [
+  ZardPaginationContentComponent,
+  ZardPaginationItemComponent,
+  ZardPaginationButtonComponent,
+  ZardPaginationPreviousComponent,
+  ZardPaginationNextComponent,
+  ZardPaginationEllipsisComponent,
+  ZardPaginationComponent,
+] as const;

--- a/v2/ui/pagination/pagination.variants.ts
+++ b/v2/ui/pagination/pagination.variants.ts
@@ -1,0 +1,38 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const paginationContentVariants = cva('flex flex-row items-center gap-1');
+export type ZardPaginationContentVariants = VariantProps<typeof paginationContentVariants>;
+
+export const paginationPreviousVariants = cva('gap-1 px-2.5 sm:pl-2.5');
+export type ZardPaginationPreviousVariants = VariantProps<typeof paginationPreviousVariants>;
+
+export const paginationNextVariants = cva('gap-1 px-2.5 sm:pr-2.5');
+export type ZardPaginationNextVariants = VariantProps<typeof paginationNextVariants>;
+
+export const paginationEllipsisVariants = cva('flex size-9 items-center justify-center');
+export type ZardPaginationEllipsisVariants = VariantProps<typeof paginationEllipsisVariants>;
+
+export const paginationVariants = cva('mx-auto flex w-full justify-center');
+export type ZardPaginationVariants = VariantProps<typeof paginationVariants>;

--- a/v2/ui/table/index.ts
+++ b/v2/ui/table/index.ts
@@ -1,0 +1,25 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './table.component';
+export * from './table.imports';
+export * from './table.variants';

--- a/v2/ui/table/table.component.ts
+++ b/v2/ui/table/table.component.ts
@@ -1,0 +1,174 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+
+import type { ClassValue } from 'clsx';
+
+import {
+  type ZardTableSizeVariants,
+  type ZardTableTypeVariants,
+  tableBodyVariants,
+  tableCaptionVariants,
+  tableCellVariants,
+  tableHeaderVariants,
+  tableHeadVariants,
+  tableRowVariants,
+  tableVariants,
+} from './table.variants';
+import { mergeClasses } from '../utils/merge-classes';
+
+@Component({
+  selector: 'table[z-table]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zTable',
+})
+export class ZardTableComponent {
+  readonly zType = input<ZardTableTypeVariants>('default');
+  readonly zSize = input<ZardTableSizeVariants>('default');
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() =>
+    mergeClasses(
+      tableVariants({
+        zType: this.zType(),
+        zSize: this.zSize(),
+      }),
+      this.class(),
+    ),
+  );
+}
+
+@Component({
+  selector: 'thead[z-table-header]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zTableHeader',
+})
+export class ZardTableHeaderComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(tableHeaderVariants(), this.class()));
+}
+
+@Component({
+  selector: 'tbody[z-table-body]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zTableBody',
+})
+export class ZardTableBodyComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(tableBodyVariants(), this.class()));
+}
+
+@Component({
+  selector: 'tr[z-table-row]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zTableRow',
+})
+export class ZardTableRowComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(tableRowVariants(), this.class()));
+}
+
+@Component({
+  selector: 'th[z-table-head]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zTableHead',
+})
+export class ZardTableHeadComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(tableHeadVariants(), this.class()));
+}
+
+@Component({
+  selector: 'td[z-table-cell]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zTableCell',
+})
+export class ZardTableCellComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(tableCellVariants(), this.class()));
+}
+
+@Component({
+  selector: 'caption[z-table-caption]',
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+  },
+  exportAs: 'zTableCaption',
+})
+export class ZardTableCaptionComponent {
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() => mergeClasses(tableCaptionVariants(), this.class()));
+}

--- a/v2/ui/table/table.imports.ts
+++ b/v2/ui/table/table.imports.ts
@@ -1,0 +1,41 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ZardTableComponent,
+  ZardTableHeaderComponent,
+  ZardTableBodyComponent,
+  ZardTableRowComponent,
+  ZardTableHeadComponent,
+  ZardTableCellComponent,
+  ZardTableCaptionComponent,
+} from './table.component';
+
+export const ZardTableImports = [
+  ZardTableComponent,
+  ZardTableHeaderComponent,
+  ZardTableBodyComponent,
+  ZardTableRowComponent,
+  ZardTableHeadComponent,
+  ZardTableCellComponent,
+  ZardTableCaptionComponent,
+] as const;

--- a/v2/ui/table/table.variants.ts
+++ b/v2/ui/table/table.variants.ts
@@ -1,0 +1,84 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const tableVariants = cva(
+  'w-full caption-bottom text-sm [&_thead_tr]:border-b [&_tbody]:border-0 [&_tbody_tr:last-child]:border-0 [&_tbody_tr]:border-b [&_tbody_tr]:transition-colors [&_tbody_tr]:hover:bg-muted/50 [&_tbody_tr]:data-[state=selected]:bg-muted [&_th]:h-10 [&_th]:px-2 [&_th]:text-left [&_th]:align-middle [&_th]:font-medium [&_th]:text-muted-foreground [&_th:has([role=checkbox])]:pr-0 [&_th>[role=checkbox]]:translate-y-0.5 [&_td]:p-2 [&_td]:align-middle [&_td:has([role=checkbox])]:pr-0 [&_td>[role=checkbox]]:translate-y-0.5 [&_caption]:mt-4 [&_caption]:text-sm [&_caption]:text-muted-foreground',
+  {
+    variants: {
+      zType: {
+        default: '',
+        striped: '[&_tbody_tr:nth-child(odd)]:bg-muted/50',
+        bordered: 'border border-border',
+      },
+      zSize: {
+        default: '',
+        compact: '[&_td]:py-2 [&_th]:py-2',
+        comfortable: '[&_td]:py-4 [&_th]:py-4',
+      },
+    },
+    defaultVariants: {
+      zType: 'default',
+      zSize: 'default',
+    },
+  },
+);
+
+export const tableHeaderVariants = cva('[&_tr]:border-b', {
+  variants: {},
+  defaultVariants: {},
+});
+
+export const tableBodyVariants = cva('[&_tr:last-child]:border-0', {
+  variants: {},
+  defaultVariants: {},
+});
+
+export const tableRowVariants = cva('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', {
+  variants: {},
+  defaultVariants: {},
+});
+
+export const tableHeadVariants = cva(
+  'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5',
+  {
+    variants: {},
+    defaultVariants: {},
+  },
+);
+
+export const tableCellVariants = cva(
+  'p-2 align-middle [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5',
+  {
+    variants: {},
+    defaultVariants: {},
+  },
+);
+
+export const tableCaptionVariants = cva('mt-4 text-sm text-muted-foreground', {
+  variants: {},
+  defaultVariants: {},
+});
+
+export type ZardTableSizeVariants = NonNullable<VariantProps<typeof tableVariants>['zSize']>;
+export type ZardTableTypeVariants = NonNullable<VariantProps<typeof tableVariants>['zType']>;

--- a/v2/ui/toast/index.ts
+++ b/v2/ui/toast/index.ts
@@ -1,0 +1,24 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './toast.component';
+export * from './toast.variants';

--- a/v2/ui/toast/toast.component.ts
+++ b/v2/ui/toast/toast.component.ts
@@ -1,0 +1,72 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+
+import type { ClassValue } from 'clsx';
+import { NgxSonnerToaster } from 'ngx-sonner';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import { toastVariants, type ZardToastVariants } from './toast.variants';
+
+@Component({
+  selector: 'z-toast, z-toaster',
+  imports: [NgxSonnerToaster],
+  template: `
+    <ngx-sonner-toaster
+      [theme]="theme()"
+      [class]="classes()"
+      [position]="position()"
+      [richColors]="richColors()"
+      [expand]="expand()"
+      [duration]="duration()"
+      [visibleToasts]="visibleToasts()"
+      [closeButton]="closeButton()"
+      [toastOptions]="toastOptions()"
+      [dir]="dir()"
+    />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zToast',
+})
+export class ZardToastComponent {
+  readonly class = input<ClassValue>('');
+  readonly variant = input<ZardToastVariants>('default');
+  readonly theme = input<'light' | 'dark' | 'system'>('system');
+  readonly position = input<'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right'>(
+    'bottom-right',
+  );
+
+  readonly richColors = input<boolean>(false);
+  readonly expand = input<boolean>(false);
+  readonly duration = input<number>(4000);
+  readonly visibleToasts = input<number>(3);
+  readonly closeButton = input<boolean>(false);
+  readonly toastOptions = input<Record<string, unknown>>({});
+  readonly dir = input<'ltr' | 'rtl' | 'auto'>('auto');
+
+  protected readonly classes = computed(() =>
+    mergeClasses('toaster group', toastVariants({ variant: this.variant() }), this.class()),
+  );
+}

--- a/v2/ui/toast/toast.variants.ts
+++ b/v2/ui/toast/toast.variants.ts
@@ -1,0 +1,41 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const toastVariants = cva(
+  'group group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+  {
+    variants: {
+      variant: {
+        default: 'group-[.toaster]:bg-background group-[.toaster]:text-foreground',
+        destructive:
+          'group-[.toaster]:bg-destructive group-[.toaster]:text-foreground group-[.toaster]:border-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+export type ZardToastVariants = NonNullable<VariantProps<typeof toastVariants>['variant']>;

--- a/v2/ui/utils/merge-classes.ts
+++ b/v2/ui/utils/merge-classes.ts
@@ -1,0 +1,44 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export type { ClassValue };
+
+export function mergeClasses(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export const noopFn = () => void 0;
+
+export const isElementContentTruncated = (element: HTMLElement | undefined): boolean => {
+  if (!element) {
+    return false;
+  }
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const rangeWidth = range.getBoundingClientRect().width;
+  const elementWidth = element.getBoundingClientRect().width;
+
+  return rangeWidth > elementWidth;
+};


### PR DESCRIPTION
## Description
Add ZardUI component library to Common-UI v2 so all AMRIT apps (104, 1097, MMU) can reuse shared UI components.

## What's included
- 8 ZardUI components: Button, Dialog, Form, Input, Loader, Pagination, Table, Toast
- Fixed all import paths (relative, no @/* alias needed)
- GPL-3.0 license headers on all new files
- README.md documenting peer dependencies
- public-api.ts updated to export v2/ui

## Notes
- Gopi's existing v2 files untouched
- Peer deps documented in v2/ui/README.md
- Full type-check will happen when host app consumes the branch

## Type of Change
- [x] New feature
