### PR TITLE
refactor: convert Common-UI v2 to standalone components

### DIFF
--- a/v2/feedback/feedback.module.ts
+++ b/v2/feedback/feedback.module.ts
@@ -25,17 +25,16 @@ import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
 
 import { FeedbackRoutingModule } from "./feedback-routing.module";
-import { MaterialModule } from "src/app/app-modules/core/material.module"; // your shared material bundle
+ // your shared material bundle
 
 import { FeedbackPublicPageComponent } from "./pages/feedback-public-page/feedback-public-page-component";
 import { FeedbackDialogComponent } from "./shared/feedback-dialog/feedback-dialog.component";
 
 import { FeedbackService } from "./services/feedback.service";
 
-@NgModule({ declarations: [FeedbackPublicPageComponent, FeedbackDialogComponent],
+@NgModule({
     exports: [FeedbackDialogComponent], imports: [CommonModule,
-        FormsModule,
-        ReactiveFormsModule,
-        MaterialModule,
-        FeedbackRoutingModule], providers: [FeedbackService, provideHttpClient(withInterceptorsFromDi())] })
+    FormsModule,
+    ReactiveFormsModule,
+    FeedbackRoutingModule, FeedbackPublicPageComponent, FeedbackDialogComponent], providers: [FeedbackService, provideHttpClient(withInterceptorsFromDi())] })
 export class FeedbackModule {}

--- a/v2/feedback/pages/feedback-public-page/feedback-public-page-component.ts
+++ b/v2/feedback/pages/feedback-public-page/feedback-public-page-component.ts
@@ -22,6 +22,7 @@
 import { Component } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { map } from "rxjs/operators";
+import { FeedbackDialogComponent } from "../../shared/feedback-dialog/feedback-dialog.component";
 
 type SL = "1097" | "104" | "AAM" | "MMU" | "TM" | "ECD";
 
@@ -44,7 +45,7 @@ type SL = "1097" | "104" | "AAM" | "MMU" | "TM" | "ECD";
       }
     `,
     ],
-    standalone: false
+    imports: [FeedbackDialogComponent]
 })
 export class FeedbackPublicPageComponent {
   serviceLine: SL = "AAM"; // default fallback

--- a/v2/feedback/shared/feedback-dialog/feedback-dialog.component.ts
+++ b/v2/feedback/shared/feedback-dialog/feedback-dialog.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, Input, OnInit } from "@angular/core";
-import { FormBuilder, Validators } from "@angular/forms";
+import { FormBuilder, Validators, ReactiveFormsModule } from "@angular/forms";
 import { Router } from "@angular/router";
 import {
   FeedbackService,
@@ -31,12 +31,13 @@ import { finalize } from "rxjs/operators";
 import { SessionStorageService } from "Common-UI/v2/registrar/services/session-storage.service";
 import { HttpServiceService } from "src/app/app-modules/core/services/http-service.service";
 import { SetLanguageComponent } from "src/app/app-modules/core/components/set-language.component";
+import { NgFor, NgIf } from "@angular/common";
 
 @Component({
     selector: "app-feedback-dialog",
     templateUrl: "./feedback-dialog.component.html",
     styleUrls: ["./feedback-dialog.component.scss"],
-    standalone: false
+    imports: [NgFor, NgIf, ReactiveFormsModule]
 })
 export class FeedbackDialogComponent implements OnInit {
   @Input() serviceLine: ServiceLine = "TM";

--- a/v2/registrar/abha-components/abha-consent-form/abha-consent-form.component.ts
+++ b/v2/registrar/abha-components/abha-consent-form/abha-consent-form.component.ts
@@ -1,13 +1,16 @@
 import { Component } from '@angular/core';
-import { FormControl } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { FormControl, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatDialogRef, MatDialogClose, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
 import { SessionStorageService } from '../../services/session-storage.service';
+import { MatIcon } from '@angular/material/icon';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { MatCheckbox } from '@angular/material/checkbox';
 
 @Component({
     selector: 'app-abha-consent-form',
     templateUrl: './abha-consent-form.component.html',
     styleUrls: ['./abha-consent-form.component.css'],
-    standalone: false
+    imports: [MatIcon, MatDialogClose, CdkScrollable, MatDialogContent, ReactiveFormsModule, FormsModule, MatCheckbox, MatDialogActions]
 })
 export class AbhaConsentFormComponent {
 

--- a/v2/registrar/abha-components/abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component.ts
+++ b/v2/registrar/abha-components/abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component.ts
@@ -1,16 +1,21 @@
 import { Component, Inject } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
+import { MatIcon } from '@angular/material/icon';
+import { NgIf } from '@angular/common';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatFormField, MatLabel } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
 
 @Component({
     selector: 'app-abha-enter-mobile-otp-component',
     templateUrl: './abha-enter-mobile-otp-component.component.html',
     styleUrls: ['./abha-enter-mobile-otp-component.component.css'],
-    standalone: false
+    imports: [MatIcon, MatDialogClose, NgIf, MatProgressSpinner, ReactiveFormsModule, MatFormField, MatLabel, MatInput]
 })
 export class AbhaEnterMobileOtpComponentComponent {
   generateMobileOTPForm!: FormGroup;

--- a/v2/registrar/abha-components/abha-enter-otp-component/abha-enter-otp-component.component.ts
+++ b/v2/registrar/abha-components/abha-enter-otp-component/abha-enter-otp-component.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
-import { FormGroup, FormBuilder } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { FormGroup, FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialog, MatDialogClose } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
@@ -9,12 +9,17 @@ import { AbhaMobileComponentComponent } from '../abha-mobile-component/abha-mobi
 import { AbhaGenerationSuccessComponentComponent } from '../abha-generation-success-component/abha-generation-success-component.component';
 import { AbhaVerifySuccessComponentComponent } from '../abha-verify-success-component/abha-verify-success-component.component';
 import { GenerateAbhaComponentComponent } from '../generate-abha-component/generate-abha-component.component';
+import { NgIf } from '@angular/common';
+import { MatIcon } from '@angular/material/icon';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatFormField, MatLabel } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
 
 @Component({
     selector: 'app-abha-enter-otp-component',
     templateUrl: './abha-enter-otp-component.component.html',
     styleUrls: ['./abha-enter-otp-component.component.css'],
-    standalone: false
+    imports: [NgIf, MatIcon, MatDialogClose, MatProgressSpinner, ReactiveFormsModule, MatFormField, MatLabel, MatInput]
 })
 export class AbhaEnterOtpComponentComponent {
 

--- a/v2/registrar/abha-components/abha-generation-success-component/abha-generation-success-component.component.ts
+++ b/v2/registrar/abha-components/abha-generation-success-component/abha-generation-success-component.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
@@ -7,12 +7,14 @@ import { AbhaEnterOtpComponentComponent } from '../abha-enter-otp-component/abha
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { DisplayAbhaCardComponent } from '../display-abha-card/display-abha-card.component';
 import { AbhaEnterMobileOtpComponentComponent } from '../abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component';
+import { NgIf } from '@angular/common';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 @Component({
     selector: 'app-abha-generation-success-component',
     templateUrl: './abha-generation-success-component.component.html',
     styleUrls: ['./abha-generation-success-component.component.css'],
-    standalone: false
+    imports: [NgIf, MatProgressSpinner, MatDialogClose]
 })
 export class AbhaGenerationSuccessComponentComponent {
 

--- a/v2/registrar/abha-components/abha-mobile-component/abha-mobile-component.component.ts
+++ b/v2/registrar/abha-components/abha-mobile-component/abha-mobile-component.component.ts
@@ -1,17 +1,22 @@
 import { Component, Inject } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { SessionStorageService } from '../../services/session-storage.service';
+import { MatIcon } from '@angular/material/icon';
+import { NgIf } from '@angular/common';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatFormField, MatLabel, MatError } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
 
 @Component({
     selector: 'app-abha-mobile-component',
     templateUrl: './abha-mobile-component.component.html',
     styleUrls: ['./abha-mobile-component.component.css'],
-    standalone: false
+    imports: [MatIcon, MatDialogClose, NgIf, MatProgressSpinner, ReactiveFormsModule, MatFormField, MatLabel, MatInput, MatError]
 })
 export class AbhaMobileComponentComponent {
   generateMobileOTPForm!: FormGroup;

--- a/v2/registrar/abha-components/abha-verify-success-component/abha-verify-success-component.component.ts
+++ b/v2/registrar/abha-components/abha-verify-success-component/abha-verify-success-component.component.ts
@@ -1,16 +1,18 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
 import { DisplayAbhaCardComponent } from '../display-abha-card/display-abha-card.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
+import { NgIf } from '@angular/common';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 @Component({
     selector: 'app-abha-verify-success-component',
     templateUrl: './abha-verify-success-component.component.html',
     styleUrls: ['./abha-verify-success-component.component.css'],
-    standalone: false
+    imports: [NgIf, MatProgressSpinner, MatDialogClose]
 })
 export class AbhaVerifySuccessComponentComponent {
 

--- a/v2/registrar/abha-components/biometric-authentication/biometric-authentication.component.ts
+++ b/v2/registrar/abha-components/biometric-authentication/biometric-authentication.component.ts
@@ -1,21 +1,18 @@
 import { Component, Inject, OnInit } from '@angular/core';
-import {
-  MAT_DIALOG_DATA,
-  MatDialog,
-  MatDialogRef,
-} from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { RegistrarService } from '../../services/registrar.service';
 import { RdDeviceService } from '../../services/rddevice.service';
 import { concatMap } from 'rxjs';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
+import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'app-biometric-authentication',
     templateUrl: './biometric-authentication.component.html',
     styleUrls: ['./biometric-authentication.component.css'],
-    standalone: false
+    imports: [MatIcon, MatDialogClose]
 })
 export class BiometricAuthenticationComponent implements OnInit {
   transactionId: any;

--- a/v2/registrar/abha-components/display-abha-card/display-abha-card.component.ts
+++ b/v2/registrar/abha-components/display-abha-card/display-abha-card.component.ts
@@ -1,15 +1,18 @@
 import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
 import { DomSanitizer } from '@angular/platform-browser';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
+import { MatIcon } from '@angular/material/icon';
+import { NgIf } from '@angular/common';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 @Component({
     selector: 'app-display-abha-card',
     templateUrl: './display-abha-card.component.html',
     styleUrls: ['./display-abha-card.component.css'],
-    standalone: false
+    imports: [MatIcon, MatDialogClose, NgIf, MatProgressSpinner]
 })
 export class DisplayAbhaCardComponent {
 

--- a/v2/registrar/abha-components/download-search-abha/download-search-abha.component.ts
+++ b/v2/registrar/abha-components/download-search-abha/download-search-abha.component.ts
@@ -1,18 +1,23 @@
 import { Component, Inject } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
 import { ConfirmationService } from 'src/app/app-modules/core/services/confirmation.service';
 import { AbhaEnterOtpComponentComponent } from '../abha-enter-otp-component/abha-enter-otp-component.component';
 import { environment } from 'src/environments/environment';
+import { MatIcon } from '@angular/material/icon';
+import { NgIf } from '@angular/common';
+import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
+import { MatFormField, MatLabel, MatError } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
 
 @Component({
     selector: 'app-download-search-abha',
     templateUrl: './download-search-abha.component.html',
     styleUrls: ['./download-search-abha.component.css'],
-    standalone: false
+    imports: [MatDialogClose, MatIcon, ReactiveFormsModule, NgIf, MatRadioGroup, MatRadioButton, MatFormField, MatLabel, MatInput, MatError]
 })
 export class DownloadSearchAbhaComponent {
   currentLanguageSet: any;

--- a/v2/registrar/abha-components/generate-abha-component/generate-abha-component.component.ts
+++ b/v2/registrar/abha-components/generate-abha-component/generate-abha-component.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { MatDialog, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
@@ -8,12 +8,17 @@ import { BiometricAuthenticationComponent } from '../biometric-authentication/bi
 import { AbhaEnterOtpComponentComponent } from '../abha-enter-otp-component/abha-enter-otp-component.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services/confirmation.service';
 import { AbhaMobileComponentComponent } from '../abha-mobile-component/abha-mobile-component.component';
+import { MatIcon } from '@angular/material/icon';
+import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
+import { MatLabel, MatFormField, MatError } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { NgIf } from '@angular/common';
 
 @Component({
     selector: 'app-generate-abha-component',
     templateUrl: './generate-abha-component.component.html',
     styleUrls: ['./generate-abha-component.component.css'],
-    standalone: false
+    imports: [MatIcon, MatDialogClose, ReactiveFormsModule, MatRadioGroup, MatRadioButton, MatLabel, MatFormField, MatInput, NgIf, MatError]
 })
 export class GenerateAbhaComponentComponent {
 

--- a/v2/registrar/abha-components/health-id-display-modal/health-id-display-modal.component.ts
+++ b/v2/registrar/abha-components/health-id-display-modal/health-id-display-modal.component.ts
@@ -20,14 +20,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, DoCheck, Inject, OnInit } from '@angular/core';
-import { FormGroup, FormBuilder } from '@angular/forms';
-import { DatePipe } from '@angular/common';
-import {
-  MAT_DIALOG_DATA,
-  MatDialog,
-  MatDialogRef,
-} from '@angular/material/dialog';
-import { MatTableDataSource } from '@angular/material/table';
+import { FormGroup, FormBuilder, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { DatePipe, NgIf } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatDialogClose } from '@angular/material/dialog';
+import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
@@ -43,6 +39,12 @@ import {
 } from '@angular/material-moment-adapter';
 import { SessionStorageService } from '../../services/session-storage.service';
 import { DownloadSearchAbhaComponent } from '../download-search-abha/download-search-abha.component';
+import { MatTooltip } from '@angular/material/tooltip';
+import { MatIcon } from '@angular/material/icon';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
+import { MatFormField } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
 
 @Component({
     selector: 'app-health-id-display-modal',
@@ -76,7 +78,7 @@ import { DownloadSearchAbhaComponent } from '../download-search-abha/download-se
             },
         },
     ],
-    standalone: false
+    imports: [NgIf, MatDialogClose, MatTooltip, MatIcon, MatProgressSpinner, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatRadioGroup, ReactiveFormsModule, FormsModule, MatRadioButton, MatFormField, MatInput, DatePipe]
 })
 export class HealthIdDisplayModalComponent implements OnInit, DoCheck {
   chooseHealthID: any;

--- a/v2/registrar/beneficiary-details/beneficiary-details.component.ts
+++ b/v2/registrar/beneficiary-details/beneficiary-details.component.ts
@@ -38,12 +38,13 @@ import { HttpServiceService } from 'src/app/app-modules/core/services/http-servi
 import { RegistrarService } from '../services/registrar.service';
 import { SessionStorageService } from '../services/session-storage.service';
 import { environment } from 'src/environments/environment';
+import { NgIf, NgFor, TitleCasePipe, DatePipe } from '@angular/common';
 
 @Component({
     selector: 'app-beneficiary-details',
     templateUrl: './beneficiary-details.component.html',
     styleUrls: ['./beneficiary-details.component.css'],
-    standalone: false
+    imports: [NgIf, NgFor, TitleCasePipe, DatePipe]
 })
 export class BeneficiaryDetailsComponent implements OnInit, DoCheck, OnDestroy {
   beneficiary: any;

--- a/v2/registrar/dashboard/dashboard.component.ts
+++ b/v2/registrar/dashboard/dashboard.component.ts
@@ -21,12 +21,15 @@
  */
 
 import { Component, OnInit } from '@angular/core';
+import { AppHeaderComponent } from '../../../../src/app/app-modules/core/components/app-header/app-header.component';
+import { RouterOutlet } from '@angular/router';
+import { AppFooterComponent } from '../../../../src/app/app-modules/core/components/app-footer/app-footer.component';
 
 @Component({
     selector: 'app-dashboard',
     templateUrl: './dashboard.component.html',
     styleUrls: ['./dashboard.component.css'],
-    standalone: false
+    imports: [AppHeaderComponent, RouterOutlet, AppFooterComponent]
 })
 export class DashboardComponent {
   constructor() {}

--- a/v2/registrar/family-tagging/create-family-tagging/create-family-tagging.component.ts
+++ b/v2/registrar/family-tagging/create-family-tagging/create-family-tagging.component.ts
@@ -20,19 +20,25 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, DoCheck, Inject, OnInit, ViewChild } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FormBuilder, FormGroup, ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { FamilyTaggingService } from '../../services/familytagging.service';
 import { SessionStorageService } from '../../services/session-storage.service';
+import { MatIcon } from '@angular/material/icon';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { MatFormField, MatLabel, MatError, MatSelect } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { NgIf, NgFor } from '@angular/common';
+import { MatOption } from '@angular/material/autocomplete';
 
 @Component({
     selector: 'app-create-family-tagging',
     templateUrl: './create-family-tagging.component.html',
     styleUrls: ['./create-family-tagging.component.css'],
-    standalone: false
+    imports: [MatIcon, CdkScrollable, MatDialogContent, ReactiveFormsModule, FormsModule, MatFormField, MatLabel, MatInput, NgIf, MatError, MatSelect, NgFor, MatOption, MatDialogActions]
 })
 export class CreateFamilyTaggingComponent implements OnInit, DoCheck {
   @ViewChild('newFamilyTaggingForm') form: any;

--- a/v2/registrar/family-tagging/edit-family-tagging/edit-family-tagging.component.ts
+++ b/v2/registrar/family-tagging/edit-family-tagging/edit-family-tagging.component.ts
@@ -20,18 +20,27 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, DoCheck, Inject, OnInit, ViewChild } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { FamilyTaggingService } from '../../services/familytagging.service';
 import { SessionStorageService } from '../../services/session-storage.service';
+import { MatIcon } from '@angular/material/icon';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
+import { NgIf, NgFor, TitleCasePipe } from '@angular/common';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatFormField, MatLabel, MatSelect, MatError } from '@angular/material/select';
+import { MatOption } from '@angular/material/autocomplete';
+import { MatInput } from '@angular/material/input';
 
 @Component({
     selector: 'app-edit-family-tagging',
     templateUrl: './edit-family-tagging.component.html',
     styleUrls: ['./edit-family-tagging.component.css'],
-    standalone: false
+    imports: [MatIcon, CdkScrollable, MatDialogContent, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, NgIf, MatCheckbox, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, ReactiveFormsModule, FormsModule, MatFormField, MatLabel, MatSelect, MatOption, NgFor, MatInput, MatError, MatDialogActions, TitleCasePipe]
 })
 export class EditFamilyTaggingComponent implements OnInit, DoCheck {
   @ViewChild('editFamilyTaggingForm')

--- a/v2/registrar/family-tagging/family-tagging-details/family-tagging-details.component.ts
+++ b/v2/registrar/family-tagging/family-tagging-details/family-tagging-details.component.ts
@@ -39,13 +39,20 @@ import { RegistrarService } from '../../services/registrar.service';
 import { SearchFamilyComponent } from '../../search-family/search-family.component';
 import { SessionStorageService } from '../../services/session-storage.service';
 import { environment } from 'src/environments/environment';
+import { MatIcon } from '@angular/material/icon';
+import { MatSidenavContainer, MatSidenav } from '@angular/material/sidenav';
+import { BeneficiaryDetailsComponent } from '../../beneficiary-details/beneficiary-details.component';
+import { MatCard } from '@angular/material/card';
+import { NgIf, NgFor, TitleCasePipe } from '@angular/common';
+import { MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
+import { MatTooltip } from '@angular/material/tooltip';
 
 
 @Component({
     selector: 'app-family-tagging-details',
     templateUrl: './family-tagging-details.component.html',
     styleUrls: ['./family-tagging-details.component.css'],
-    standalone: false
+    imports: [MatIcon, MatSidenavContainer, MatSidenav, BeneficiaryDetailsComponent, MatCard, NgIf, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, NgFor, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatTooltip, MatPaginator, TitleCasePipe]
 })
 export class FamilyTaggingDetailsComponent
   implements OnInit, DoCheck, OnDestroy

--- a/v2/registrar/registration.module.ts
+++ b/v2/registrar/registration.module.ts
@@ -91,11 +91,6 @@ import { AbhaConsentFormComponent } from './abha-components/abha-consent-form/ab
         HealthIdDisplayModalComponent,
         BeneficiaryDetailsComponent,
     ],
-    providers: [
-        RegistrarService,
-        RegistrationService,
-        FamilyTaggingService,
-        RdDeviceService
-    ]
+    providers: [],
 })
 export class RegistrationModule { }

--- a/v2/registrar/registration.module.ts
+++ b/v2/registrar/registration.module.ts
@@ -7,7 +7,7 @@ import { LocationInformationComponent } from './registration/location-informatio
 import { OtherInformationComponent } from './registration/other-information/other-information.component';
 import { AbhaInformationComponent } from './registration/abha-information/abha-information.component';
 import { MatStepperModule } from '@angular/material/stepper';
-import { MaterialModule } from 'src/app/app-modules/core/material.module';
+
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { RegistrationComponent } from './registration/registration.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -25,7 +25,7 @@ import { EditFamilyTaggingComponent } from './family-tagging/edit-family-tagging
 import { HealthIdDisplayModalComponent } from './abha-components/health-id-display-modal/health-id-display-modal.component';
 import { SearchFamilyComponent } from './search-family/search-family.component';
 import { BeneficiaryDetailsComponent } from './beneficiary-details/beneficiary-details.component';
-import { SharedModule } from 'src/app/app-modules/core/components/shared/shared.module';
+
 import { FamilyTaggingService } from './services/familytagging.service';
 import { ConsentFormComponent } from './registration/consent-form/consent-form.component';
 import { RdDeviceService } from './services/rddevice.service';
@@ -40,7 +40,15 @@ import { AbhaEnterMobileOtpComponentComponent } from './abha-components/abha-ent
 import { AbhaConsentFormComponent } from './abha-components/abha-consent-form/abha-consent-form.component';
 
 @NgModule({
-  declarations: [
+    imports: [
+    CommonModule,
+    MatStepperModule,
+    ReactiveFormsModule,
+    FormsModule,
+    RegistrationRoutingModule,
+    MatTableModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
     PersonalInformationComponent,
     LocationInformationComponent,
     OtherInformationComponent,
@@ -65,41 +73,29 @@ import { AbhaConsentFormComponent } from './abha-components/abha-consent-form/ab
     DisplayAbhaCardComponent,
     AbhaVerifySuccessComponentComponent,
     AbhaEnterMobileOtpComponentComponent,
-    AbhaConsentFormComponent,
-  ],
-  imports: [
-    CommonModule,
-    MaterialModule,
-    MatStepperModule,
-    ReactiveFormsModule,
-    FormsModule,
-    RegistrationRoutingModule,
-    SharedModule,
-    MatTableModule,
-    MatDatepickerModule,
-    MatNativeDateModule
-  ],
-  exports: [
-    PersonalInformationComponent,
-    LocationInformationComponent,
-    OtherInformationComponent,
-    AbhaInformationComponent,
-    RegistrationComponent,
-    SearchComponent,
-    SearchDialogComponent,
-    BiometricAuthenticationComponent,
-    FamilyTaggingDetailsComponent,
-    CreateFamilyTaggingComponent,
-    EditFamilyTaggingComponent,
-    GenerateAbhaComponentComponent,
-    HealthIdDisplayModalComponent,
-    BeneficiaryDetailsComponent,
-  ],
-  providers: [
-    RegistrarService,
-    RegistrationService,
-    FamilyTaggingService,
-    RdDeviceService
-  ]
+    AbhaConsentFormComponent
+],
+    exports: [
+        PersonalInformationComponent,
+        LocationInformationComponent,
+        OtherInformationComponent,
+        AbhaInformationComponent,
+        RegistrationComponent,
+        SearchComponent,
+        SearchDialogComponent,
+        BiometricAuthenticationComponent,
+        FamilyTaggingDetailsComponent,
+        CreateFamilyTaggingComponent,
+        EditFamilyTaggingComponent,
+        GenerateAbhaComponentComponent,
+        HealthIdDisplayModalComponent,
+        BeneficiaryDetailsComponent,
+    ],
+    providers: [
+        RegistrarService,
+        RegistrationService,
+        FamilyTaggingService,
+        RdDeviceService
+    ]
 })
 export class RegistrationModule { }

--- a/v2/registrar/registration/abha-information/abha-information.component.ts
+++ b/v2/registrar/registration/abha-information/abha-information.component.ts
@@ -6,18 +6,21 @@ import { HealthIdDisplayModalComponent } from '../../abha-components/health-id-d
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
-import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { FormControl, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { GenerateAbhaComponentComponent } from '../../abha-components/generate-abha-component/generate-abha-component.component';
 import { DownloadSearchAbhaComponent } from '../../abha-components/download-search-abha/download-search-abha.component';
 import { AbhaConsentFormComponent } from '../../abha-components/abha-consent-form/abha-consent-form.component';
 import { AmritTrackingService } from 'Common-UI/v2/tracking';
+import { NgIf, NgFor } from '@angular/common';
+import { MatFormField, MatLabel } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
 
 @Component({
     selector: 'app-abha-information',
     templateUrl: './abha-information.component.html',
     styleUrls: ['./abha-information.component.css'],
-    standalone: false
+    imports: [NgIf, ReactiveFormsModule, NgFor, MatFormField, MatLabel, MatInput]
 })
 export class AbhaInformationComponent {
 

--- a/v2/registrar/registration/consent-form/consent-form.component.ts
+++ b/v2/registrar/registration/consent-form/consent-form.component.ts
@@ -20,17 +20,19 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { Consent, SearchComponent } from 'Common-UI/v2/registrar/search/search.component';
+import { MatIcon } from '@angular/material/icon';
+import { CdkScrollable } from '@angular/cdk/scrolling';
 
 @Component({
     selector: 'app-consent-form',
     templateUrl: './consent-form.component.html',
     styleUrls: ['./consent-form.component.css'],
-    standalone: false
+    imports: [MatIcon, CdkScrollable, MatDialogContent, MatDialogActions]
 })
 export class ConsentFormComponent implements OnInit {
   currentLanguageSet: any;

--- a/v2/registrar/registration/location-information/location-information.component.ts
+++ b/v2/registrar/registration/location-information/location-information.component.ts
@@ -1,23 +1,22 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import {
-  AbstractControl,
-  FormArray,
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  Validators,
-} from '@angular/forms';
+import { AbstractControl, FormArray, FormBuilder, FormControl, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { RegistrarService } from '../../services/registrar.service';
 import { Subscription } from 'rxjs';
 import { SessionStorageService } from '../../services/session-storage.service';
 import { AmritTrackingService } from 'Common-UI/v2/tracking'
 import { Injector } from '@angular/core';
+import { NgFor, NgIf, TitleCasePipe } from '@angular/common';
+import { MatFormField, MatLabel, MatError, MatSuffix, MatSelect } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
+import { MatOption, MatAutocompleteTrigger, MatAutocomplete } from '@angular/material/autocomplete';
+import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 
 @Component({
     selector: 'app-location-information',
     templateUrl: './location-information.component.html',
     styleUrls: ['./location-information.component.css'],
-    standalone: false
+    imports: [ReactiveFormsModule, NgFor, NgIf, MatFormField, MatLabel, MatInput, MatError, MatDatepickerInput, MatDatepickerToggle, MatSuffix, MatDatepicker, MatSelect, MatOption, MatRadioGroup, MatRadioButton, MatAutocompleteTrigger, MatAutocomplete, TitleCasePipe]
 })
 export class LocationInformationComponent {
   @Input()

--- a/v2/registrar/registration/other-information/other-information.component.ts
+++ b/v2/registrar/registration/other-information/other-information.component.ts
@@ -1,21 +1,21 @@
 import { Component, Input } from '@angular/core';
-import {
-  AbstractControl,
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  Validators,
-} from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { RegistrarService } from '../../services/registrar.service';
 import { Subscription } from 'rxjs';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ConsentFormComponent } from '../consent-form/consent-form.component';
+import { NgFor, NgIf } from '@angular/common';
+import { MatFormField, MatLabel, MatError, MatSuffix, MatSelect } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
+import { MatOption } from '@angular/material/autocomplete';
+import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 
 @Component({
     selector: 'app-other-information',
     templateUrl: './other-information.component.html',
     styleUrls: ['./other-information.component.css'],
-    standalone: false
+    imports: [ReactiveFormsModule, NgFor, NgIf, MatFormField, MatLabel, MatInput, MatError, MatDatepickerInput, MatDatepickerToggle, MatSuffix, MatDatepicker, MatSelect, MatOption, MatRadioGroup, MatRadioButton]
 })
 export class OtherInformationComponent {
   @Input('otherInfoFormGroup')

--- a/v2/registrar/registration/personal-information/personal-information.component.ts
+++ b/v2/registrar/registration/personal-information/personal-information.component.ts
@@ -1,12 +1,5 @@
 import { Component, Input } from '@angular/core';
-import {
-  AbstractControl,
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  ValidatorFn,
-  Validators,
-} from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidatorFn, Validators, ReactiveFormsModule } from '@angular/forms';
 import {
   BeneficiaryDetailsService,
   CameraService,
@@ -29,6 +22,12 @@ import { HttpServiceService } from 'src/app/app-modules/core/services/http-servi
 import { AmritTrackingService } from 'Common-UI/v2/tracking';
 import { Injector } from '@angular/core';
 import { environment } from 'src/environments/environment';
+import { NgIf, NgFor } from '@angular/common';
+import { MatFormField, MatLabel, MatError, MatSuffix, MatSelect } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
+import { MatOption } from '@angular/material/autocomplete';
+import { MatRadioGroup, MatRadioButton } from '@angular/material/radio';
 
 
 @Component({
@@ -60,7 +59,7 @@ import { environment } from 'src/environments/environment';
             },
         },
     ],
-    standalone: false
+    imports: [ReactiveFormsModule, NgIf, NgFor, MatFormField, MatLabel, MatInput, MatError, MatDatepickerInput, MatDatepickerToggle, MatSuffix, MatDatepicker, MatSelect, MatOption, MatRadioGroup, MatRadioButton]
 })
 export class PersonalInformationComponent {
   @Input()

--- a/v2/registrar/registration/registration.component.ts
+++ b/v2/registrar/registration/registration.component.ts
@@ -1,15 +1,7 @@
 import { Component, ViewChild } from '@angular/core';
 import { RegistrationService } from '../services/registration.service';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
-import {
-  AbstractControl,
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  ValidationErrors,
-  ValidatorFn,
-  Validators,
-} from '@angular/forms';
+import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators, ReactiveFormsModule } from '@angular/forms';
 import { RegistrarService } from '../services/registrar.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
@@ -19,12 +11,19 @@ import * as moment from 'moment';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { ConsentFormComponent } from './consent-form/consent-form.component';
 import { SessionStorageService } from '../services/session-storage.service';
+import { NgIf } from '@angular/common';
+import { MatStepper, MatStep, MatStepLabel, MatStepperNext, MatStepperPrevious } from '@angular/material/stepper';
+import { MatCard, MatCardTitle, MatCardContent } from '@angular/material/card';
+import { PersonalInformationComponent } from './personal-information/personal-information.component';
+import { LocationInformationComponent } from './location-information/location-information.component';
+import { OtherInformationComponent } from './other-information/other-information.component';
+import { AbhaInformationComponent } from './abha-information/abha-information.component';
 
 @Component({
     selector: 'app-registration',
     templateUrl: './registration.component.html',
     styleUrls: ['./registration.component.css'],
-    standalone: false
+    imports: [NgIf, ReactiveFormsModule, MatStepper, MatStep, MatStepLabel, MatCard, MatCardTitle, MatCardContent, PersonalInformationComponent, MatStepperNext, LocationInformationComponent, MatStepperPrevious, OtherInformationComponent, AbhaInformationComponent]
 })
 export class RegistrationComponent {
 

--- a/v2/registrar/search-dialog/search-dialog.component.ts
+++ b/v2/registrar/search-dialog/search-dialog.component.ts
@@ -28,8 +28,8 @@ import {
   AfterViewChecked,
   DoCheck,
 } from '@angular/core';
-import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { FormBuilder, FormGroup, Validators, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogRef, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { CommonService } from 'src/app/app-modules/core/services/common-services.service';
@@ -47,6 +47,13 @@ import {
 } from '@angular/material-moment-adapter';
 import { SessionStorageService } from '../services/session-storage.service';
 import { map, Observable, startWith } from 'rxjs';
+import { MatIcon } from '@angular/material/icon';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { MatFormField, MatLabel, MatError, MatSelect, MatSuffix } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
+import { NgIf, NgFor, AsyncPipe, TitleCasePipe } from '@angular/common';
+import { MatOption, MatAutocompleteTrigger, MatAutocomplete } from '@angular/material/autocomplete';
+import { MatDatepickerInput, MatDatepickerToggle, MatDatepicker } from '@angular/material/datepicker';
 
 interface Beneficary {
   firstName: string;
@@ -90,7 +97,7 @@ interface Beneficary {
             },
         },
     ],
-    standalone: false
+    imports: [MatIcon, CdkScrollable, MatDialogContent, ReactiveFormsModule, MatFormField, MatLabel, MatInput, NgIf, MatError, MatSelect, NgFor, MatOption, MatDatepickerInput, MatDatepickerToggle, MatSuffix, MatDatepicker, MatAutocompleteTrigger, MatAutocomplete, MatDialogActions, MatDialogClose, AsyncPipe, TitleCasePipe]
 })
 export class SearchDialogComponent implements OnInit, DoCheck {
   // for ID Manpulation

--- a/v2/registrar/search-family/search-family.component.ts
+++ b/v2/registrar/search-family/search-family.component.ts
@@ -29,20 +29,22 @@ import {
   HostListener,
   DoCheck,
 } from '@angular/core';
-import {
-  MatDialogRef,
-  MatDialog,
-  MatDialogConfig,
-  MAT_DIALOG_DATA,
-} from '@angular/material/dialog';
+import { MatDialogRef, MatDialog, MatDialogConfig, MAT_DIALOG_DATA, MatDialogContent, MatDialogActions } from '@angular/material/dialog';
 import { Router } from '@angular/router';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { CommonService } from 'src/app/app-modules/core/services/common-services.service';
 import { RegistrarService } from '../services/registrar.service';
 import { FamilyTaggingService } from '../services/familytagging.service';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
+import { MatIcon } from '@angular/material/icon';
+import { NgIf, NgFor, TitleCasePipe } from '@angular/common';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+import { MatFormField, MatLabel, MatSelect, MatError } from '@angular/material/select';
+import { MatOption } from '@angular/material/autocomplete';
+import { MatInput } from '@angular/material/input';
 
 interface Beneficary {
   village: string;
@@ -57,7 +59,7 @@ interface Beneficary {
     selector: 'app-search-family',
     templateUrl: './search-family.component.html',
     styleUrls: ['./search-family.component.css'],
-    standalone: false
+    imports: [MatIcon, NgIf, MatProgressSpinner, CdkScrollable, MatDialogContent, ReactiveFormsModule, MatFormField, MatLabel, MatSelect, NgFor, MatOption, MatInput, MatError, MatDialogActions, TitleCasePipe]
 })
 export class SearchFamilyComponent implements OnInit, DoCheck {
   masterData: any;

--- a/v2/registrar/search/search.component.ts
+++ b/v2/registrar/search/search.component.ts
@@ -33,7 +33,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { SearchDialogComponent } from '../search-dialog/search-dialog.component';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatPaginator } from '@angular/material/paginator';
-import { MatTableDataSource } from '@angular/material/table';
+import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import {
   ConfirmationService,
@@ -48,6 +48,13 @@ import { SessionStorageService } from '../services/session-storage.service';
 import { HealthIdDisplayModalComponent } from '../abha-components/health-id-display-modal/health-id-display-modal.component';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap } from 'rxjs/operators';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatTooltip } from '@angular/material/tooltip';
+import { MatIcon } from '@angular/material/icon';
+import { MatCard } from '@angular/material/card';
+import { NgIf, TitleCasePipe } from '@angular/common';
+import { MatFormField, MatSuffix } from '@angular/material/select';
+import { MatInput } from '@angular/material/input';
 
 export interface Consent {
   consentGranted: string;
@@ -57,7 +64,7 @@ export interface Consent {
     selector: 'app-search',
     templateUrl: './search.component.html',
     styleUrls: ['./search.component.css'],
-    standalone: false
+    imports: [ReactiveFormsModule, FormsModule, MatTooltip, MatIcon, MatCard, NgIf, MatFormField, MatInput, MatSuffix, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow, MatPaginator, TitleCasePipe]
 })
 export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDestroy {
   rowsPerPage = 5;

--- a/v2/registrar/services/familytagging.service.ts
+++ b/v2/registrar/services/familytagging.service.ts
@@ -24,7 +24,9 @@ import { HttpClient } from '@angular/common/http';
 import { environment } from 'src/environments/environment';
 import { map } from 'rxjs/operators';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class FamilyTaggingService {
   constructor(private http: HttpClient) {}
 

--- a/v2/registrar/services/registrar.service.ts
+++ b/v2/registrar/services/registrar.service.ts
@@ -25,7 +25,9 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
 import { environment } from 'src/environments/environment';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class RegistrarService {
   consentGranted = '0';
 


### PR DESCRIPTION
## Description
  Convert `Common-UI/v2` to **standalone components**, matching MMU-UI's standalone
  migration. Paired with the MMU-UI PR (`standalone-migration → angular-zard-migration`).

  > `v2/` only — the original `src/` (Angular 16, used by HWC/ECD/AAM) is untouched.

  ## What changed
  - `v2/` components/directives flipped to `standalone: true` (declarations → imports).
  - **Fix:** `RegistrarService` and `FamilyTaggingService` are now `providedIn: 'root'`
    and `RegistrationModule.providers` emptied. Standalone components opened via
    `MatDialog` (e.g. `SearchDialogComponent`) resolve through the **root** injector,
    not the lazy module injector — module-scoped providers caused
    `NG0201: No provider for RegistrarService`. Root-providing keeps a single shared
    instance and fixes advanced search.

  ## Verification
  - Consumed by MMU-UI via the submodule pointer; MMU `build-prod` passes and the app
    boots (advanced-search dialog confirmed working).

  ## Note
  Common-UI is a shared submodule (HWC/ECD/AAM use `src/`); this PR changes only `v2/`.