### PR TITLE
feat(ui): add Zard select component + event-manager provider

### DIFF
--- a/v2/ui/provider/event-manager-plugins/zard-debounce-event-manager-plugin.ts
+++ b/v2/ui/provider/event-manager-plugins/zard-debounce-event-manager-plugin.ts
@@ -1,0 +1,55 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import type { ListenerOptions } from '@angular/core';
+import { EventManagerPlugin } from '@angular/platform-browser';
+
+export class ZardDebounceEventManagerPlugin extends EventManagerPlugin {
+  override supports(eventName: string): boolean {
+    return /\.debounce(?:\.|$)/.test(eventName);
+  }
+
+  override addEventListener(
+    element: HTMLElement,
+    eventName: string,
+    handler: (event: Event) => void,
+    options?: ListenerOptions,
+    // eslint-disable-next-line
+  ): Function {
+    // Expected format: "event.debounce.delay" (e.g., "input.debounce.150")
+    // If delay is omitted or invalid, defaults to 300ms
+    const [event, , delay] = eventName.split('.');
+    const parsedDelay = Number.parseInt(delay);
+    const resolvedDelay = Number.isNaN(parsedDelay) ? 300 : parsedDelay;
+
+    let timeoutId!: ReturnType<typeof setTimeout>;
+    const listener = (event: Event) => {
+      clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => handler(event), resolvedDelay);
+    };
+    const unsubscribe = this.manager.addEventListener(element, event, listener, options);
+    return () => {
+      clearTimeout(timeoutId);
+      unsubscribe();
+    };
+  }
+}

--- a/v2/ui/provider/event-manager-plugins/zard-debounce-event-manager-plugin.ts
+++ b/v2/ui/provider/event-manager-plugins/zard-debounce-event-manager-plugin.ts
@@ -33,7 +33,7 @@ export class ZardDebounceEventManagerPlugin extends EventManagerPlugin {
     eventName: string,
     handler: (event: Event) => void,
     options?: ListenerOptions,
-    // eslint-disable-next-line
+    // eslint-disable-next-line @typescript-eslint/ban-types
   ): Function {
     // Expected format: "event.debounce.delay" (e.g., "input.debounce.150")
     // If delay is omitted or invalid, defaults to 300ms

--- a/v2/ui/provider/event-manager-plugins/zard-event-manager-plugin.ts
+++ b/v2/ui/provider/event-manager-plugins/zard-event-manager-plugin.ts
@@ -46,7 +46,7 @@ import { EventManagerPlugin } from '@angular/platform-browser';
  * (click.stop)="handler()"
  */
 export class ZardEventManagerPlugin extends EventManagerPlugin {
-  #keywords = ['prevent', 'stop', 'stop-immediate', 'prevent-with-stop'];
+  readonly #keywords = ['prevent', 'stop', 'stop-immediate', 'prevent-with-stop'];
 
   override supports(eventName: string): boolean {
     return this.#keywords.some(keyword => eventName.endsWith(`.${keyword}`));
@@ -57,7 +57,7 @@ export class ZardEventManagerPlugin extends EventManagerPlugin {
     eventName: string,
     handler: (event: Event) => void,
     options?: ListenerOptions,
-    // eslint-disable-next-line
+    // eslint-disable-next-line @typescript-eslint/ban-types
   ): Function {
     const { event, keyword, keys } = this.#provideEventFrom(eventName, this.#keywords);
     return this.manager.addEventListener(
@@ -101,14 +101,13 @@ export class ZardEventManagerPlugin extends EventManagerPlugin {
     for (const substring of eventNameSubstrings) {
       if (substring.startsWith('{')) {
         keys = this.#extractKeys(substring);
-        continue;
       } else if (keywords.includes(substring)) {
         keyword = substring;
         break;
-      } else if (!event) {
-        event = substring;
-      } else {
+      } else if (event) {
         event += `.${substring}`;
+      } else {
+        event = substring;
       }
     }
 

--- a/v2/ui/provider/event-manager-plugins/zard-event-manager-plugin.ts
+++ b/v2/ui/provider/event-manager-plugins/zard-event-manager-plugin.ts
@@ -1,0 +1,128 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import type { ListenerOptions } from '@angular/core';
+import { EventManagerPlugin } from '@angular/platform-browser';
+
+/**
+ * Angular EventManagerPlugin that provides event modifier syntax for templates.
+ *
+ * Supports modifiers: .prevent, .stop, .stop-immediate, .prevent-with-stop
+ * Supports key filters: enter, escape, {enter,space}
+ *
+ * @example
+ * Prevent default on any click
+ * (click.prevent)="handler()"
+ *
+ * @example
+ * Prevent default only on Enter key
+ * (keydown.enter.prevent)="handler()"
+ *
+ * @example
+ * Prevent default on more keys like Enter and Space key
+ * (keydown.{enter,space}.prevent)="handler()"
+ *
+ * @example
+ * Stop propagation
+ * (click.stop)="handler()"
+ */
+export class ZardEventManagerPlugin extends EventManagerPlugin {
+  #keywords = ['prevent', 'stop', 'stop-immediate', 'prevent-with-stop'];
+
+  override supports(eventName: string): boolean {
+    return this.#keywords.some(keyword => eventName.endsWith(`.${keyword}`));
+  }
+
+  override addEventListener(
+    element: HTMLElement,
+    eventName: string,
+    handler: (event: Event) => void,
+    options?: ListenerOptions,
+    // eslint-disable-next-line
+  ): Function {
+    const { event, keyword, keys } = this.#provideEventFrom(eventName, this.#keywords);
+    return this.manager.addEventListener(
+      element,
+      event,
+      (event: Event) => {
+        const isKeyboardEvent = event instanceof KeyboardEvent;
+        const isElementDisabled = element.getAttribute('aria-disabled') === 'true';
+        const shouldApplyModifier =
+          (!keys.length || (isKeyboardEvent && keys.includes(event.key.toLowerCase()))) && !isElementDisabled;
+
+        if (shouldApplyModifier) {
+          switch (keyword) {
+            case 'stop':
+              event.stopPropagation();
+              break;
+            case 'stop-immediate':
+              event.stopImmediatePropagation();
+              break;
+            case 'prevent-with-stop':
+              event.preventDefault();
+              event.stopPropagation();
+              break;
+            default:
+              event.preventDefault();
+              break;
+          }
+        }
+        handler(event);
+      },
+      options,
+    );
+  }
+
+  #provideEventFrom(eventName: string, keywords: string[]): { event: string; keyword: string; keys: string[] } {
+    const eventNameSubstrings = eventName.split('.');
+    let event = '';
+    let keys: string[] = [];
+    let keyword = '';
+
+    for (const substring of eventNameSubstrings) {
+      if (substring.startsWith('{')) {
+        keys = this.#extractKeys(substring);
+        continue;
+      } else if (keywords.includes(substring)) {
+        keyword = substring;
+        break;
+      } else if (!event) {
+        event = substring;
+      } else {
+        event += `.${substring}`;
+      }
+    }
+
+    return { event, keyword, keys };
+  }
+
+  #extractKeys(substring: string): string[] {
+    const stringList = substring.substring(1, substring.length - 1);
+    return stringList
+      .split(',')
+      .map(raw => {
+        const s = raw.toLowerCase().trim();
+        return s === 'space' ? ' ' : s;
+      })
+      .filter(Boolean);
+  }
+}

--- a/v2/ui/provider/index.ts
+++ b/v2/ui/provider/index.ts
@@ -20,13 +20,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+export * from './providezard';
+export * from './event-manager-plugins/zard-event-manager-plugin';
+export * from './event-manager-plugins/zard-debounce-event-manager-plugin';

--- a/v2/ui/provider/providezard.ts
+++ b/v2/ui/provider/providezard.ts
@@ -20,13 +20,25 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+import { makeEnvironmentProviders, type EnvironmentProviders } from '@angular/core';
+import { EVENT_MANAGER_PLUGINS } from '@angular/platform-browser';
+
+import { ZardDebounceEventManagerPlugin } from './event-manager-plugins/zard-debounce-event-manager-plugin';
+import { ZardEventManagerPlugin } from './event-manager-plugins/zard-event-manager-plugin';
+
+export function provideZard(): EnvironmentProviders {
+  const eventManagerPlugins = [
+    {
+      provide: EVENT_MANAGER_PLUGINS,
+      useClass: ZardEventManagerPlugin,
+      multi: true,
+    },
+    {
+      provide: EVENT_MANAGER_PLUGINS,
+      useClass: ZardDebounceEventManagerPlugin,
+      multi: true,
+    },
+  ];
+
+  return makeEnvironmentProviders([...eventManagerPlugins]);
+}

--- a/v2/ui/select/index.ts
+++ b/v2/ui/select/index.ts
@@ -20,13 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+export * from './select.component';
+export * from './select-item.component';
+export * from './select.imports';
+export * from './select.variants';

--- a/v2/ui/select/select-item.component.ts
+++ b/v2/ui/select/select-item.component.ts
@@ -1,0 +1,125 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  ElementRef,
+  inject,
+  input,
+  linkedSignal,
+  signal,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCheck } from '@ng-icons/lucide';
+
+import {
+  selectItemIconVariants,
+  selectItemVariants,
+  type ZardSelectItemModeVariants,
+  type ZardSelectSizeVariants,
+} from './select.variants';
+import { mergeClasses, noopFn } from '../utils/merge-classes';
+
+// Interface to avoid circular dependency
+interface SelectHost {
+  selectedValue(): string[];
+  selectItem(value: string, label: string): void;
+  navigateTo(): void;
+}
+
+@Component({
+  selector: 'z-select-item, [z-select-item]',
+  imports: [NgIcon],
+  template: `
+    @if (isSelected()) {
+      <span [class]="iconClasses()">
+        <ng-icon name="lucideCheck" aria-hidden="true" data-testid="check-icon" />
+      </span>
+    }
+    <span class="min-w-0 flex-1 break-words whitespace-normal">
+      <ng-content />
+    </span>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  viewProviders: [provideIcons({ lucideCheck })],
+  host: {
+    role: 'option',
+    tabindex: '-1',
+    '[class]': 'classes()',
+    '[attr.value]': 'zValue()',
+    '[attr.data-disabled]': 'zDisabled() ? "" : null',
+    '[attr.data-selected]': 'isSelected() ? "" : null',
+    '[attr.aria-selected]': 'isSelected()',
+    '(click)': 'onClick()',
+    '(mouseenter)': 'onMouseEnter()',
+    '(keydown.{tab}.prevent)': 'noopFn',
+  },
+})
+export class ZardSelectItemComponent {
+  readonly elementRef = inject(ElementRef<HTMLElement>);
+
+  readonly zValue = input.required<string>();
+  readonly zDisabled = input(false, { transform: booleanAttribute });
+  readonly class = input<string>('');
+
+  private readonly select = signal<SelectHost | null>(null);
+  noopFn = noopFn;
+
+  readonly label = linkedSignal<string>(() => {
+    const element = this.elementRef.nativeElement;
+    return (element.textContent ?? element.innerText)?.trim() ?? '';
+  });
+
+  readonly zMode = signal<ZardSelectItemModeVariants>('normal');
+  readonly zSize = signal<ZardSelectSizeVariants>('default');
+
+  protected readonly classes = computed(() =>
+    mergeClasses(selectItemVariants({ zMode: this.zMode(), zSize: this.zSize() }), this.class()),
+  );
+
+  protected readonly iconClasses = computed(() =>
+    mergeClasses(selectItemIconVariants({ zMode: this.zMode(), zSize: this.zSize() })),
+  );
+
+  protected readonly isSelected = computed(() => this.select()?.selectedValue().includes(this.zValue()) ?? false);
+
+  setSelectHost(selectHost: SelectHost) {
+    this.select.set(selectHost);
+  }
+
+  onMouseEnter() {
+    if (this.zDisabled()) {
+      return;
+    }
+    this.select()?.navigateTo();
+  }
+
+  onClick() {
+    if (this.zDisabled()) {
+      return;
+    }
+    this.select()?.selectItem(this.zValue(), this.label());
+  }
+}

--- a/v2/ui/select/select.component.ts
+++ b/v2/ui/select/select.component.ts
@@ -1,0 +1,665 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { Overlay, OverlayModule, OverlayPositionBuilder, type OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { isPlatformBrowser } from '@angular/common';
+import {
+  afterNextRender,
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  contentChildren,
+  DestroyRef,
+  effect,
+  ElementRef,
+  forwardRef,
+  inject,
+  Injector,
+  input,
+  model,
+  type OnDestroy,
+  output,
+  PLATFORM_ID,
+  runInInjectionContext,
+  signal,
+  type TemplateRef,
+  viewChild,
+  ViewContainerRef,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronDown } from '@ng-icons/lucide';
+
+import type { ClassValue } from 'clsx';
+import { filter } from 'rxjs';
+
+import { ZardSelectItemComponent } from './select-item.component';
+import {
+  selectContentVariants,
+  selectTriggerVariants,
+  selectVariants,
+  type ZardSelectSizeVariants,
+} from './select.variants';
+import { mergeClasses } from '../utils/merge-classes';
+
+type OnTouchedType = () => void;
+type OnChangeType = (value: string) => void;
+
+const COMPACT_MODE_WIDTH_THRESHOLD = 100;
+
+@Component({
+  selector: 'z-select, [z-select]',
+  imports: [OverlayModule, NgIcon],
+  template: `
+    <button
+      type="button"
+      role="combobox"
+      aria-controls="dropdown"
+      [class]="triggerClasses()"
+      [disabled]="zDisabled()"
+      [attr.aria-expanded]="isOpen()"
+      [attr.aria-haspopup]="'listbox'"
+      [attr.data-placeholder]="!zValue() ? '' : null"
+      (blur)="!isOpen() && isFocus.set(false)"
+      (click)="toggle()"
+      (focus)="onFocus()"
+    >
+      <span class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+        @for (label of selectedLabels(); track label) {
+          @if (zMultiple()) {
+            <span
+              class="inline-flex items-center gap-1 rounded-md border border-transparent bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
+            >
+              <span class="truncate">{{ label }}</span>
+            </span>
+          } @else {
+            <span class="min-w-0 flex-1 truncate text-left">{{ label }}</span>
+          }
+        } @empty {
+          <span class="text-muted-foreground min-w-0 flex-1 truncate text-left">{{ zPlaceholder() }}</span>
+        }
+      </span>
+      <ng-icon name="lucideChevronDown" class="opacity-50" aria-hidden="true" />
+    </button>
+
+    <ng-template #dropdownTemplate>
+      <div
+        id="dropdown"
+        [class]="contentClasses()"
+        role="listbox"
+        [attr.data-state]="'open'"
+        (keydown.{arrowdown,arrowup,enter,space,escape,home,end}.prevent)="onDropdownKeydown($event)"
+        tabindex="-1"
+      >
+        <div class="p-1">
+          <ng-content />
+        </div>
+      </div>
+    </ng-template>
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ZardSelectComponent),
+      multi: true,
+    },
+  ],
+  viewProviders: [provideIcons({ lucideChevronDown })],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[attr.data-active]': 'isFocus() ? "" : null',
+    '[attr.data-disabled]': 'zDisabled() ? "" : null',
+    '[attr.data-state]': 'isOpen() ? "open" : "closed"',
+    '[class]': 'classes()',
+    '(keydown.{enter,space,arrowdown,arrowup,escape}.prevent)': 'onTriggerKeydown($event)',
+  },
+})
+export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private readonly injector = inject(Injector);
+  private readonly overlay = inject(Overlay);
+  private readonly overlayPositionBuilder = inject(OverlayPositionBuilder);
+  private readonly viewContainerRef = inject(ViewContainerRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  readonly dropdownTemplate = viewChild.required<TemplateRef<void>>('dropdownTemplate');
+  readonly selectItems = contentChildren(ZardSelectItemComponent);
+
+  private overlayRef?: OverlayRef;
+  private portal?: TemplatePortal;
+
+  readonly class = input<ClassValue>('');
+  readonly zDisabled = input(false, { transform: booleanAttribute });
+  readonly zLabel = input<string>('');
+  readonly zMaxLabelCount = input<number>(1);
+  readonly zMultiple = input<boolean>(false);
+  readonly zPlaceholder = input<string>('Select an option...');
+  readonly zSize = input<ZardSelectSizeVariants>('default');
+  readonly zValue = model<string | string[]>(this.zMultiple() ? [] : '');
+
+  readonly zSelectionChange = output<string | string[]>();
+
+  readonly isOpen = signal(false);
+  readonly focusedIndex = signal<number>(-1);
+  protected readonly isFocus = signal(false);
+  protected readonly isCompact = signal(false);
+
+  protected onFocus(): void {
+    if (this.isCompact()) {
+      this.isFocus.set(true);
+    }
+  }
+
+  // Compute the label based on selected value
+  readonly selectedLabels = computed<string[]>(() => {
+    const selectedValue = this.zValue();
+    if (this.zMultiple() && Array.isArray(selectedValue)) {
+      return this.provideLabelsForMultiselectMode(selectedValue);
+    }
+
+    return this.provideLabelForSingleSelectMode(selectedValue as string);
+  });
+
+  private onChange: OnChangeType = (_value: string) => {
+    // ControlValueAccessor onChange callback
+  };
+
+  private onTouched: OnTouchedType = () => {
+    // ControlValueAccessor onTouched callback
+  };
+
+  protected readonly classes = computed(() => mergeClasses(selectVariants(), this.class()));
+  protected readonly contentClasses = computed(() => mergeClasses(selectContentVariants()));
+  protected readonly triggerClasses = computed(() =>
+    mergeClasses(
+      selectTriggerVariants({
+        zSize: this.zSize(),
+      }),
+    ),
+  );
+
+  constructor() {
+    // The items are projected into the dropdown's <ng-template>, so they are
+    // only created once the overlay opens — after ngAfterContentInit has run.
+    // Wire each item's host reference reactively whenever the projected items
+    // change, otherwise click-to-select would no-op (the item's selectItem
+    // callback stays unset). Keyboard selection does not rely on this because
+    // it calls selectItem() on this component directly.
+    effect(() => {
+      const items = this.selectItems();
+      const hostWidth = this.elementRef.nativeElement.offsetWidth || 0;
+      const compact = hostWidth > 0 && hostWidth <= COMPACT_MODE_WIDTH_THRESHOLD;
+      if (compact) {
+        this.isCompact.set(true);
+      }
+      items.forEach((item, index) => {
+        item.setSelectHost({
+          selectedValue: () => (this.zMultiple() ? (this.zValue() as string[]) : [this.zValue() as string]),
+          selectItem: (value: string, label: string) => this.selectItem(value, label),
+          navigateTo: () => this.navigateTo(item, index),
+        });
+        item.zSize.set(this.zSize());
+        if (compact) {
+          item.zMode.set('compact');
+        }
+      });
+    });
+  }
+
+  ngOnDestroy() {
+    this.destroyOverlay();
+  }
+
+  onTriggerKeydown(event: Event) {
+    const { key } = event as KeyboardEvent;
+    switch (key) {
+      case 'Enter':
+      case ' ':
+      case 'ArrowDown':
+      case 'ArrowUp':
+        if (!this.isOpen()) {
+          this.open();
+        }
+        break;
+      case 'Escape':
+        if (this.isOpen()) {
+          this.close();
+        }
+        break;
+    }
+  }
+
+  onDropdownKeydown(e: Event) {
+    const { key } = e as KeyboardEvent;
+    const items = this.getSelectItems();
+
+    switch (key) {
+      case 'ArrowDown':
+        this.navigateItems(1, items);
+        break;
+      case 'ArrowUp':
+        this.navigateItems(-1, items);
+        break;
+      case 'Enter':
+      case ' ':
+        this.selectFocusedItem(items);
+        break;
+      case 'Escape':
+        this.close();
+        this.focusButton();
+        break;
+      case 'Home':
+        this.focusFirstItem(items);
+        break;
+      case 'End':
+        this.focusLastItem(items);
+        break;
+    }
+  }
+
+  toggle() {
+    if (this.zDisabled()) {
+      return;
+    }
+
+    if (this.isOpen()) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  selectItem(value: string, label: string) {
+    if (value === undefined || value === null || value === '') {
+      console.warn('Attempted to select item with invalid value:', { value, label });
+      return;
+    }
+
+    this.zValue.update(selectedValues => {
+      if (Array.isArray(selectedValues)) {
+        return selectedValues.includes(value) ? selectedValues.filter(v => v !== value) : [...selectedValues, value];
+      }
+
+      return value;
+    });
+    this.onChange(value);
+    this.zSelectionChange.emit(this.zValue());
+
+    if (this.zMultiple()) {
+      // in multiple mode it can happen that button changes size because of selection badges,
+      // which requires overlay position to update
+      this.updateOverlayPosition();
+    } else {
+      this.close();
+
+      // Return focus to the button after selection
+      setTimeout(() => {
+        this.focusButton();
+      }, 0);
+    }
+  }
+
+  private navigateTo(element: ZardSelectItemComponent, index: number): void {
+    this.focusedIndex.set(index);
+    this.updateItemFocus(this.getSelectItems(true), index);
+  }
+
+  private updateOverlayPosition(): void {
+    setTimeout(() => {
+      this.overlayRef?.updatePosition();
+    }, 0);
+  }
+
+  private provideLabelsForMultiselectMode(selectedValue: string[]): string[] {
+    const labelsToShowCount = selectedValue.length - this.zMaxLabelCount();
+    const labels = [];
+    let index = 0;
+    for (const value of selectedValue) {
+      const matchingItem = this.getMatchingItem(value);
+      if (matchingItem) {
+        labels.push(matchingItem.label());
+        index++;
+      }
+      if (labelsToShowCount && this.zMaxLabelCount() && index === this.zMaxLabelCount()) {
+        labels.push(`${labelsToShowCount} more item${labelsToShowCount > 1 ? 's' : ''} selected`);
+        break;
+      }
+    }
+    return labels;
+  }
+
+  private provideLabelForSingleSelectMode(selectedValue: string): string[] {
+    const manualLabel = this.zLabel();
+    if (manualLabel) {
+      return [manualLabel];
+    }
+
+    const matchingItem = this.getMatchingItem(selectedValue);
+    if (matchingItem) {
+      return [matchingItem.label()];
+    }
+
+    return selectedValue ? [selectedValue] : [];
+  }
+
+  private open() {
+    if (this.isOpen()) {
+      return;
+    }
+
+    // Create overlay if it doesn't exist
+    if (!this.overlayRef) {
+      this.createOverlay();
+    }
+
+    if (!this.overlayRef) {
+      return;
+    }
+
+    const hostWidth = this.elementRef.nativeElement.offsetWidth || 0;
+
+    if (this.overlayRef.hasAttached()) {
+      this.overlayRef.detach();
+    }
+
+    this.portal = new TemplatePortal(this.dropdownTemplate(), this.viewContainerRef);
+
+    this.overlayRef.attach(this.portal);
+    this.overlayRef.updateSize({ width: hostWidth });
+    this.isOpen.set(true);
+    this.updateFocusWhenNormalMode();
+
+    this.determinePortalWidthOnOpen(hostWidth);
+  }
+
+  private setFocusOnOpen(): void {
+    this.focusDropdown();
+    this.focusSelectedItem();
+  }
+
+  private close() {
+    if (this.overlayRef?.hasAttached()) {
+      this.overlayRef.detach();
+    }
+    this.isOpen.set(false);
+    this.focusedIndex.set(-1);
+    this.onTouched();
+    this.updateFocusWhenNormalMode();
+  }
+
+  private updateFocusWhenNormalMode(): void {
+    if (!this.isCompact()) {
+      this.isFocus.set(!this.isOpen());
+    }
+  }
+
+  private getMatchingItem(value: string): ZardSelectItemComponent | undefined {
+    return this.selectItems()?.find(item => item.zValue() === value);
+  }
+
+  private determinePortalWidthOnOpen(portalWidth: number): void {
+    runInInjectionContext(this.injector, () => {
+      afterNextRender(() => {
+        if (!this.overlayRef || !this.overlayRef.hasAttached()) {
+          return;
+        }
+
+        const overlayPaneElement = this.overlayRef.overlayElement;
+        const textElements = Array.from(
+          overlayPaneElement.querySelectorAll<HTMLElement>(
+            'z-select-item > span.truncate, [z-select-item] > span.truncate',
+          ),
+        );
+        let isOverflow = false;
+        for (const textElement of textElements) {
+          if (textElement.scrollWidth > textElement.clientWidth + 1) {
+            isOverflow = true;
+            break;
+          }
+        }
+
+        if (!isOverflow) {
+          this.setFocusOnOpen();
+          return;
+        }
+
+        const selectItems = this.selectItems();
+        let itemMaxWidth = 0;
+        for (const item of selectItems) {
+          itemMaxWidth = Math.max(itemMaxWidth, item.elementRef.nativeElement.scrollWidth);
+        }
+
+        const [selectItem] = selectItems;
+        if (isOverflow && selectItem) {
+          const elementStyles = getComputedStyle(selectItem.elementRef.nativeElement);
+          const leftPadding = Number.parseFloat(elementStyles.getPropertyValue('padding-left')) || 0;
+          const rightPadding = Number.parseFloat(elementStyles.getPropertyValue('padding-right')) || 0;
+          itemMaxWidth += leftPadding + rightPadding;
+        }
+
+        itemMaxWidth = Math.max(itemMaxWidth, portalWidth);
+        this.overlayRef.updateSize({ width: itemMaxWidth });
+        this.overlayRef.updatePosition();
+
+        this.setFocusOnOpen();
+      });
+    });
+  }
+
+  private createOverlay() {
+    if (this.overlayRef) {
+      return;
+    } // Already created
+
+    if (isPlatformBrowser(this.platformId)) {
+      try {
+        const positionStrategy = this.overlayPositionBuilder
+          .flexibleConnectedTo(this.elementRef)
+          .withPositions([
+            {
+              originX: 'center',
+              originY: 'bottom',
+              overlayX: 'center',
+              overlayY: 'top',
+              offsetY: 4,
+            },
+            {
+              originX: 'center',
+              originY: 'top',
+              overlayX: 'center',
+              overlayY: 'bottom',
+              offsetY: -4,
+            },
+          ])
+          .withPush(false);
+
+        const elementWidth = this.elementRef.nativeElement.offsetWidth || 200;
+
+        this.overlayRef = this.overlay.create({
+          positionStrategy,
+          hasBackdrop: false,
+          scrollStrategy: this.overlay.scrollStrategies.reposition(),
+          width: elementWidth,
+          maxHeight: 384, // max-h-96 equivalent
+        });
+        this.overlayRef
+          .outsidePointerEvents()
+          .pipe(
+            filter(event => !this.elementRef.nativeElement.contains(event.target)),
+            takeUntilDestroyed(this.destroyRef),
+          )
+          .subscribe(() => {
+            this.isFocus.set(false);
+            this.close();
+          });
+      } catch (error) {
+        console.error('Error creating overlay:', error);
+      }
+    }
+  }
+
+  private destroyOverlay() {
+    if (this.overlayRef) {
+      this.overlayRef.dispose();
+      this.overlayRef = undefined;
+    }
+  }
+
+  private getSelectItems(ignoreFilter = false): HTMLElement[] {
+    if (!this.overlayRef?.hasAttached()) {
+      return [];
+    }
+    const dropdownElement = this.overlayRef.overlayElement;
+    return Array.from(dropdownElement.querySelectorAll<HTMLElement>('z-select-item, [z-select-item]')).filter(
+      item => ignoreFilter || item.dataset['disabled'] === undefined,
+    );
+  }
+
+  private navigateItems(direction: number, items: HTMLElement[]) {
+    if (items.length === 0) {
+      return;
+    }
+
+    const currentIndex = this.focusedIndex();
+    let nextIndex = currentIndex + direction;
+
+    if (nextIndex < 0) {
+      nextIndex = items.length - 1;
+    } else if (nextIndex >= items.length) {
+      nextIndex = 0;
+    }
+
+    this.focusedIndex.set(nextIndex);
+    this.updateItemFocus(items, nextIndex);
+  }
+
+  private selectFocusedItem(items: HTMLElement[]) {
+    const currentIndex = this.focusedIndex();
+    if (currentIndex >= 0 && currentIndex < items.length) {
+      const item = items[currentIndex];
+      const value = item.getAttribute('value');
+      const label = item.textContent?.trim() ?? '';
+
+      if (value === null || value === undefined) {
+        console.warn('No value attribute found on selected item:', item);
+        return;
+      }
+
+      this.selectItem(value, label);
+    }
+  }
+
+  private focusFirstItem(items: HTMLElement[]) {
+    if (items.length > 0) {
+      this.focusedIndex.set(0);
+      this.updateItemFocus(items, 0);
+    }
+  }
+
+  private focusLastItem(items: HTMLElement[]) {
+    if (items.length > 0) {
+      const lastIndex = items.length - 1;
+      this.focusedIndex.set(lastIndex);
+      this.updateItemFocus(items, lastIndex);
+    }
+  }
+
+  private updateItemFocus(items: HTMLElement[], focusedIndex: number) {
+    for (let index = 0; index < items.length; index++) {
+      const item = items[index];
+      if (index === focusedIndex) {
+        item.focus();
+        item.setAttribute('aria-selected', 'true');
+        item.setAttribute('data-selected', 'true');
+      } else {
+        item.removeAttribute('aria-selected');
+        item.removeAttribute('data-selected');
+      }
+    }
+  }
+
+  private focusDropdown() {
+    if (this.overlayRef?.hasAttached()) {
+      const dropdownElement = this.overlayRef.overlayElement.querySelector('[role="listbox"]') as HTMLElement;
+      if (dropdownElement) {
+        dropdownElement.focus();
+      }
+    }
+  }
+
+  private focusButton() {
+    const button = this.elementRef.nativeElement.querySelector('button');
+    if (button) {
+      button.focus();
+    }
+  }
+
+  private focusSelectedItem() {
+    const items = this.getSelectItems();
+    if (items.length === 0) {
+      return;
+    }
+
+    // Find the index of the currently selected item
+    let selectedValue;
+    if (Array.isArray(this.zValue()) && this.zValue().length) {
+      [selectedValue] = this.zValue();
+    } else {
+      selectedValue = this.zValue();
+    }
+
+    let selectedIndex = items.findIndex(item => item.getAttribute('value') === selectedValue);
+
+    // If no item is selected, focus the first item
+    if (selectedIndex === -1) {
+      selectedIndex = 0;
+    }
+
+    this.focusedIndex.set(selectedIndex);
+    this.updateItemFocus(items, selectedIndex);
+  }
+
+  // ControlValueAccessor implementation
+  writeValue(value: string | string[] | null): void {
+    if (this.zMultiple() && Array.isArray(value)) {
+      this.zValue.set(value);
+    } else {
+      this.zValue.set(value ?? '');
+    }
+  }
+
+  registerOnChange(fn: (value: string) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(): void {
+    // The disabled state is handled by the disabled input
+  }
+}

--- a/v2/ui/select/select.component.ts
+++ b/v2/ui/select/select.component.ts
@@ -423,7 +423,7 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
   private determinePortalWidthOnOpen(portalWidth: number): void {
     runInInjectionContext(this.injector, () => {
       afterNextRender(() => {
-        if (!this.overlayRef || !this.overlayRef.hasAttached()) {
+        if (!this.overlayRef?.hasAttached()) {
           return;
         }
 
@@ -593,10 +593,10 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
       if (index === focusedIndex) {
         item.focus();
         item.setAttribute('aria-selected', 'true');
-        item.setAttribute('data-selected', 'true');
+        item.dataset['selected'] = 'true';
       } else {
         item.removeAttribute('aria-selected');
-        item.removeAttribute('data-selected');
+        delete item.dataset['selected'];
       }
     }
   }

--- a/v2/ui/select/select.imports.ts
+++ b/v2/ui/select/select.imports.ts
@@ -20,13 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+import { ZardSelectComponent } from './select.component';
+import { ZardSelectItemComponent } from './select-item.component';
+
+export const ZardSelectImports = [ZardSelectComponent, ZardSelectItemComponent] as const;

--- a/v2/ui/select/select.variants.ts
+++ b/v2/ui/select/select.variants.ts
@@ -1,0 +1,105 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+export const selectVariants = cva(
+  mergeClasses(
+    'relative inline-block w-full rounded-md group data-active:border data-active:border-ring data-active:ring-ring/50 data-active:ring-[3px]',
+    '[&_button]:focus-visible:border [&_button]:focus-visible:border-ring [&_button]:focus-visible:ring-ring/50 [&_button]:focus-visible:ring-[3px]',
+  ),
+);
+
+export const selectTriggerVariants = cva(
+  mergeClasses(
+    'flex w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent',
+    'shadow-xs transition-[color,box-shadow] outline-none cursor-pointer disabled:cursor-not-allowed',
+    'disabled:opacity-50 data-placeholder:text-muted-foreground [&_svg:not([class*="text-"])]:text-muted-foreground',
+    'dark:bg-input/30 dark:hover:bg-input/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+    'aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4',
+  ),
+  {
+    variants: {
+      zSize: {
+        sm: 'min-h-8 py-1 text-xs px-2',
+        default: 'min-h-9 py-1.5 px-3 text-sm',
+        lg: 'min-h-10 py-2 text-base px-4',
+      },
+    },
+    defaultVariants: {
+      zSize: 'default',
+    },
+  },
+);
+export const selectContentVariants = cva(
+  'z-9999 min-w-full overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-lg animate-in fade-in-0 zoom-in-95',
+);
+export const selectItemVariants = cva(
+  'relative flex min-w-full cursor-pointer items-center gap-2 rounded-sm mb-0.5 outline-hidden select-none hover:bg-accent hover:text-accent-foreground data-selected:bg-accent data-selected:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 data-disabled:cursor-not-allowed data-disabled:hover:bg-transparent data-disabled:hover:text-current [&_svg:not([class*="text-"])]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*="size-"])]:size-4',
+  {
+    variants: {
+      zSize: {
+        sm: 'min-h-8 py-1 text-xs',
+        default: 'min-h-9 py-1.5 text-sm',
+        lg: 'min-h-10 py-2 text-base',
+      },
+      zMode: {
+        normal: 'pr-8 pl-2',
+        compact: 'pl-6.5 pr-2',
+      },
+    },
+    compoundVariants: [
+      {
+        zMode: 'compact',
+        zSize: 'sm',
+        class: 'pl-5 pr-2',
+      },
+    ],
+  },
+);
+
+export const selectItemIconVariants = cva('absolute flex size-3.5 items-center justify-center', {
+  variants: {
+    // zSize variants are placeholders for compound variant matching
+    zSize: {
+      sm: '',
+      default: '',
+      lg: '',
+    },
+    zMode: {
+      normal: 'right-2',
+      compact: 'left-2',
+    },
+  },
+  compoundVariants: [
+    {
+      zMode: 'compact',
+      zSize: 'sm',
+      class: 'left-1',
+    },
+  ],
+});
+
+export type ZardSelectSizeVariants = NonNullable<VariantProps<typeof selectTriggerVariants>['zSize']>;
+export type ZardSelectItemModeVariants = NonNullable<VariantProps<typeof selectItemVariants>['zMode']>;


### PR DESCRIPTION
 ## What

  Adds the **select** primitive to `v2/ui` the highest-priority shared component (~310 combined uses across MMU + Helpline104/1097) plus the`provideZard()` event-manager provider it depends on.

  ### `v2/ui/select/`
  - `z-select` / `z-select-item` ported from ZardUI
  - Single + multiple selection, CDK-overlay dropdown, full keyboard navigation
    (↑/↓, Enter, Esc, Home/End), and `ControlValueAccessor` so it works with
    both reactive and template-driven (`ngModel`) forms
  - Icons via `@ng-icons/lucide` (no dependency on a Zard icon component)
  - Multi-select chips use a Tailwind-styled span (no badge dependency)
  - Dropdown items **wrap** long option text; the trigger truncates the
    selected value

  ### `v2/ui/provider/`
  - `provideZard()` registering the Zard event-manager plugins that power the
    `(keydown.{enter,space,…}.prevent)` multi-key + `.debounce` template syntax
    the select relies on. **Consumer apps must call `provideZard()` in their
    bootstrap**, otherwise keyboard navigation silently no-ops.

  ## Notes
  - All files carry the AMRIT GPL-3.0 header and use relative imports (no `@/*`).
  - Exported from `v2/ui/index.ts`.
  - Verified by building it inside MMU-UI and consuming it on a real screen
    (the security-questions form) — single-select, click + keyboard select, and
    the cascade all work.