### PR TITLE
feat(ui): add Zard radio component + shared id directive

### DIFF
--- a/v2/ui/directives/id.directive.ts
+++ b/v2/ui/directives/id.directive.ts
@@ -35,7 +35,7 @@ class ZardIdInternalService {
   exportAs: 'zardId',
 })
 export class ZardIdDirective {
-  private idService = inject(ZardIdInternalService);
+  private readonly idService = inject(ZardIdInternalService);
 
   readonly zardId = input('ssr');
 

--- a/v2/ui/directives/id.directive.ts
+++ b/v2/ui/directives/id.directive.ts
@@ -20,15 +20,24 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './dialog';
-export * from './directives';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './provider';
-export * from './radio';
-export * from './select';
-export * from './table';
-export * from './toast';
+import { Directive, inject, Injectable, input, computed } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+class ZardIdInternalService {
+  private counter = 0;
+  generate(prefix: string) {
+    return `${prefix}-${++this.counter}`;
+  }
+}
+
+@Directive({
+  selector: '[zardId]',
+  exportAs: 'zardId',
+})
+export class ZardIdDirective {
+  private idService = inject(ZardIdInternalService);
+
+  readonly zardId = input('ssr');
+
+  readonly id = computed(() => this.idService.generate(this.zardId()));
+}

--- a/v2/ui/directives/index.ts
+++ b/v2/ui/directives/index.ts
@@ -20,15 +20,4 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './dialog';
-export * from './directives';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './provider';
-export * from './radio';
-export * from './select';
-export * from './table';
-export * from './toast';
+export * from './id.directive';

--- a/v2/ui/radio/index.ts
+++ b/v2/ui/radio/index.ts
@@ -20,15 +20,5 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './dialog';
-export * from './directives';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './provider';
-export * from './radio';
-export * from './select';
-export * from './table';
-export * from './toast';
+export * from './radio.component';
+export * from './radio.variants';

--- a/v2/ui/radio/radio.component.ts
+++ b/v2/ui/radio/radio.component.ts
@@ -30,6 +30,7 @@ import {
   inject,
   input,
   output,
+  signal,
   ViewEncapsulation,
 } from '@angular/core';
 import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
@@ -50,8 +51,7 @@ type OnChangeType = (value: unknown) => void;
   template: `
     <span
       class="relative flex items-center gap-2"
-      [class]="disabled() ? 'cursor-not-allowed' : 'cursor-pointer'"
-      (mousedown)="onRadioChange()"
+      [class]="isDisabled() ? 'cursor-not-allowed' : 'cursor-pointer'"
       zardId="radio"
       #z="zardId"
     >
@@ -61,7 +61,8 @@ type OnChangeType = (value: unknown) => void;
         [value]="value()"
         [class]="classes()"
         [checked]="checked"
-        [disabled]="disabled()"
+        [disabled]="isDisabled()"
+        (change)="onRadioChange()"
         (blur)="onRadioBlur()"
         [name]="name()"
         [id]="zId() || z.id()"
@@ -86,7 +87,7 @@ type OnChangeType = (value: unknown) => void;
   exportAs: 'zRadio',
 })
 export class ZardRadioComponent implements ControlValueAccessor {
-  private cdr = inject(ChangeDetectorRef);
+  private readonly cdr = inject(ChangeDetectorRef);
 
   readonly radioChange = output<boolean>();
   readonly class = input<ClassValue>('');
@@ -103,6 +104,10 @@ export class ZardRadioComponent implements ControlValueAccessor {
   protected readonly classes = computed(() => mergeClasses(radioVariants(), this.class()));
   protected readonly labelClasses = computed(() => mergeClasses(radioLabelVariants()));
 
+  // Form-driven disabled state (FormControl.disable()), combined with the input.
+  private readonly formDisabled = signal(false);
+  protected readonly isDisabled = computed(() => this.disabled() || this.formDisabled());
+
   checked = false;
 
   writeValue(val: unknown): void {
@@ -118,9 +123,10 @@ export class ZardRadioComponent implements ControlValueAccessor {
     this.onTouched = fn;
   }
 
-  setDisabledState(_isDisabled: boolean): void {
-    // This is called by Angular forms when the disabled state changes
-    // The input disabled() signal handles the state
+  setDisabledState(disabledState: boolean): void {
+    // Called by Angular forms (e.g. FormControl.disable()); combined with the
+    // disabled() input via the isDisabled computed.
+    this.formDisabled.set(disabledState);
     this.cdr.markForCheck();
   }
 
@@ -130,7 +136,7 @@ export class ZardRadioComponent implements ControlValueAccessor {
   }
 
   onRadioChange(): void {
-    if (this.disabled()) {
+    if (this.isDisabled()) {
       return;
     }
 

--- a/v2/ui/radio/radio.component.ts
+++ b/v2/ui/radio/radio.component.ts
@@ -1,0 +1,142 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  computed,
+  forwardRef,
+  inject,
+  input,
+  output,
+  ViewEncapsulation,
+} from '@angular/core';
+import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import type { ClassValue } from 'clsx';
+
+import { ZardIdDirective } from '../directives';
+import { mergeClasses } from '../utils/merge-classes';
+
+import { radioLabelVariants, radioVariants } from './radio.variants';
+
+type OnTouchedType = () => unknown;
+type OnChangeType = (value: unknown) => void;
+
+@Component({
+  selector: 'z-radio, [z-radio]',
+  imports: [ZardIdDirective],
+  template: `
+    <span
+      class="relative flex items-center gap-2"
+      [class]="disabled() ? 'cursor-not-allowed' : 'cursor-pointer'"
+      (mousedown)="onRadioChange()"
+      zardId="radio"
+      #z="zardId"
+    >
+      <input
+        #input
+        type="radio"
+        [value]="value()"
+        [class]="classes()"
+        [checked]="checked"
+        [disabled]="disabled()"
+        (blur)="onRadioBlur()"
+        [name]="name()"
+        [id]="zId() || z.id()"
+      />
+      <span
+        class="bg-primary pointer-events-none absolute left-1 size-2 rounded-full opacity-0 peer-checked:opacity-100"
+      ></span>
+      <label [class]="labelClasses()" [for]="zId() || z.id()">
+        <ng-content />
+      </label>
+    </span>
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ZardRadioComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zRadio',
+})
+export class ZardRadioComponent implements ControlValueAccessor {
+  private cdr = inject(ChangeDetectorRef);
+
+  readonly radioChange = output<boolean>();
+  readonly class = input<ClassValue>('');
+  readonly disabled = input(false, { transform: booleanAttribute });
+  readonly name = input<string>('radio');
+  readonly value = input<unknown>(null);
+  readonly zId = input<string>('');
+
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+  private onChange: OnChangeType = () => {};
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+  private onTouched: OnTouchedType = () => {};
+
+  protected readonly classes = computed(() => mergeClasses(radioVariants(), this.class()));
+  protected readonly labelClasses = computed(() => mergeClasses(radioLabelVariants()));
+
+  checked = false;
+
+  writeValue(val: unknown): void {
+    this.checked = val === this.value();
+    this.cdr.markForCheck();
+  }
+
+  registerOnChange(fn: OnChangeType): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: OnTouchedType): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(_isDisabled: boolean): void {
+    // This is called by Angular forms when the disabled state changes
+    // The input disabled() signal handles the state
+    this.cdr.markForCheck();
+  }
+
+  onRadioBlur(): void {
+    this.onTouched();
+    this.cdr.markForCheck();
+  }
+
+  onRadioChange(): void {
+    if (this.disabled()) {
+      return;
+    }
+
+    this.checked = true;
+    this.onChange(this.value());
+    this.radioChange.emit(this.checked);
+    this.cdr.markForCheck();
+  }
+}

--- a/v2/ui/radio/radio.variants.ts
+++ b/v2/ui/radio/radio.variants.ts
@@ -20,15 +20,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './dialog';
-export * from './directives';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './provider';
-export * from './radio';
-export * from './select';
-export * from './table';
-export * from './toast';
+import { cva } from 'class-variance-authority';
+
+export const radioVariants = cva(
+  'cursor-[unset] peer appearance-none rounded-full border border-input bg-background shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30 aspect-square shrink-0 size-4',
+);
+
+export const radioLabelVariants = cva('text-sm empty:hidden peer-disabled:opacity-50 peer-disabled:cursor-not-allowed');


### PR DESCRIPTION
## What

Adds the **radio** primitive to `v2/ui` (next on the priority list after select), plus a small shared `ZardIdDirective` it relies on.

### `v2/ui/radio/`
- `z-radio` ported from ZardUI: a single radio button with `ControlValueAccessor`.
- Grouping is the native pattern — give several `<z-radio>` the same `name` and bind `formControlName`/`ngModel`; CVA keeps exactly one checked. So each Material `mat-radio-button` → one `z-radio` (replacing `mat-radio-group`).
- OnPush, focus-ring, disabled state, and the checked dot all use theme tokens. No icons needed.

### `v2/ui/directives/`
- `ZardIdDirective` (`zardId`) — an SSR-safe unique-id generator (root service + counter, no `Math.random`) for label↔input association. Put in a shared folder because checkbox and other future components will reuse it.

## Notes
- Faithful port: the component/variants/index are identical to ZardUI's source apart from relative import paths and the AMRIT GPL-3.0 header.
- Exported from `v2/ui/index.ts`.
- Verified by building it inside MMU-UI (consumed in a screen, then reverted); lint clean.
- Known upstream limitation (unchanged from ZardUI): selection is driven by `(mousedown)` + CVA, so mouse selection works; native keyboard arrow-key navigation within a group does not update the model. Can add a `(change)` handler later if needed.

## Next in the priority list
tabs → checkbox → tooltip → card → …

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new radio control for forms with built-in value binding, disabled state, and change notifications.
  * Added a reusable ID helper directive to generate stable, prefixed IDs.
  * Expanded UI exports so the new radio and directive APIs are available from the main UI entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->