### PR TITLE
feat(ui): add Zard datepicker (+ popover, calendar prerequisites)

### DIFF
--- a/v2/ui/calendar/calendar-grid.component.ts
+++ b/v2/ui/calendar/calendar-grid.component.ts
@@ -54,14 +54,13 @@ import { calendarDayButtonVariants, calendarDayVariants, calendarWeekdayVariants
       <!-- Calendar Days Grid -->
       <div class="mt-2 grid w-fit auto-rows-min grid-cols-7 gap-0" role="rowgroup">
         @for (day of calendarDays(); track day.date.getTime(); let i = $index) {
-          <div [class]="dayContainerClasses()" role="gridcell">
+          <div [class]="dayContainerClasses()" role="gridcell" [attr.aria-selected]="day.isSelected">
             <button
               type="button"
               [id]="getDayId(i)"
               [class]="dayButtonClasses(day)"
               (click)="onDayClick(day.date, i)"
               [disabled]="day.isDisabled"
-              [attr.aria-selected]="day.isSelected"
               [attr.aria-label]="getDayAriaLabel(day)"
               [attr.tabindex]="getFocusedDayIndex() === i ? 0 : -1"
               role="button"
@@ -249,9 +248,10 @@ export class ZardCalendarGridComponent {
   private navigate(currentIndex: number, step: number, days: CalendarDay[]): number | null {
     const targetIndex = currentIndex + step;
 
-    // If within bounds, find enabled day
+    // If within bounds, find an enabled day searching in the requested
+    // direction (backward for Left/Up so focus never moves the wrong way).
     if (targetIndex >= 0 && targetIndex < days.length) {
-      return this.findEnabledInRange(targetIndex, currentIndex, days);
+      return this.findEnabledInRange(targetIndex, currentIndex, days, step < 0);
     }
 
     // Handle month boundaries

--- a/v2/ui/calendar/calendar-grid.component.ts
+++ b/v2/ui/calendar/calendar-grid.component.ts
@@ -154,7 +154,7 @@ export class ZardCalendarGridComponent {
 
     // Fall back to first enabled day of current month
     const firstCurrentMonthIndex = days.findIndex(day => day.isCurrentMonth && !day.isDisabled);
-    return firstCurrentMonthIndex >= 0 ? firstCurrentMonthIndex : 0;
+    return Math.max(firstCurrentMonthIndex, 0);
   }
 
   /**
@@ -278,20 +278,7 @@ export class ZardCalendarGridComponent {
     const clampedStart = Math.max(0, Math.min(start, days.length - 1));
     const clampedFallback = Math.max(0, Math.min(fallback, days.length - 1));
 
-    if (!reverse) {
-      // Search forward from start
-      for (let i = clampedStart; i < days.length; i++) {
-        if (!days[i].isDisabled) {
-          return i;
-        }
-      }
-      // Search backward from start
-      for (let i = clampedStart - 1; i >= 0; i--) {
-        if (!days[i].isDisabled) {
-          return i;
-        }
-      }
-    } else {
+    if (reverse) {
       // Search backward from start
       for (let i = clampedStart; i >= 0; i--) {
         if (!days[i].isDisabled) {
@@ -300,6 +287,19 @@ export class ZardCalendarGridComponent {
       }
       // Search forward from start
       for (let i = clampedStart + 1; i < days.length; i++) {
+        if (!days[i].isDisabled) {
+          return i;
+        }
+      }
+    } else {
+      // Search forward from start
+      for (let i = clampedStart; i < days.length; i++) {
+        if (!days[i].isDisabled) {
+          return i;
+        }
+      }
+      // Search backward from start
+      for (let i = clampedStart - 1; i >= 0; i--) {
         if (!days[i].isDisabled) {
           return i;
         }

--- a/v2/ui/calendar/calendar-grid.component.ts
+++ b/v2/ui/calendar/calendar-grid.component.ts
@@ -199,21 +199,18 @@ export class ZardCalendarGridComponent {
       case 'ArrowDown':
         newIndex = this.navigate(currentIndex, 7, days);
         break;
-      case 'Home':
-        newIndex = this.findEnabledInRange(
-          Math.floor(currentIndex / 7) * 7,
-          Math.floor(currentIndex / 7) * 7 + 6,
-          days,
-        );
+      case 'Home': {
+        const rowStart = Math.floor(currentIndex / 7) * 7;
+        // Stay within the current week (bound the search to this row).
+        newIndex = this.findEnabledInRange(rowStart, rowStart, days, false, rowStart, rowStart + 6);
         break;
-      case 'End':
-        newIndex = this.findEnabledInRange(
-          Math.floor(currentIndex / 7) * 7 + 6,
-          Math.floor(currentIndex / 7) * 7,
-          days,
-          true,
-        );
+      }
+      case 'End': {
+        const rowStart = Math.floor(currentIndex / 7) * 7;
+        const rowEnd = rowStart + 6;
+        newIndex = this.findEnabledInRange(rowEnd, rowEnd, days, true, rowStart, rowEnd);
         break;
+      }
       case 'PageUp':
         if (event.ctrlKey) {
           this.navigateYear.emit(-1);
@@ -274,32 +271,41 @@ export class ZardCalendarGridComponent {
     return null;
   }
 
-  private findEnabledInRange(start: number, fallback: number, days: CalendarDay[], reverse = false): number {
-    const clampedStart = Math.max(0, Math.min(start, days.length - 1));
-    const clampedFallback = Math.max(0, Math.min(fallback, days.length - 1));
+  private findEnabledInRange(
+    start: number,
+    fallback: number,
+    days: CalendarDay[],
+    reverse = false,
+    lo = 0,
+    hi = days.length - 1,
+  ): number {
+    // lo/hi bound the search window (defaults to the whole month; Home/End pass
+    // the current week so focus can't jump into an adjacent row).
+    const clampedStart = Math.max(lo, Math.min(start, hi));
+    const clampedFallback = Math.max(lo, Math.min(fallback, hi));
 
     if (reverse) {
       // Search backward from start
-      for (let i = clampedStart; i >= 0; i--) {
+      for (let i = clampedStart; i >= lo; i--) {
         if (!days[i].isDisabled) {
           return i;
         }
       }
       // Search forward from start
-      for (let i = clampedStart + 1; i < days.length; i++) {
+      for (let i = clampedStart + 1; i <= hi; i++) {
         if (!days[i].isDisabled) {
           return i;
         }
       }
     } else {
       // Search forward from start
-      for (let i = clampedStart; i < days.length; i++) {
+      for (let i = clampedStart; i <= hi; i++) {
         if (!days[i].isDisabled) {
           return i;
         }
       }
       // Search backward from start
-      for (let i = clampedStart - 1; i >= 0; i--) {
+      for (let i = clampedStart - 1; i >= lo; i--) {
         if (!days[i].isDisabled) {
           return i;
         }

--- a/v2/ui/calendar/calendar-grid.component.ts
+++ b/v2/ui/calendar/calendar-grid.component.ts
@@ -1,0 +1,319 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  type ElementRef,
+  input,
+  output,
+  signal,
+  viewChild,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import type { CalendarDay } from './calendar.types';
+import { calendarWeekdays, getDayAriaLabel, getDayId } from './calendar.utils';
+import { calendarDayButtonVariants, calendarDayVariants, calendarWeekdayVariants } from './calendar.variants';
+
+@Component({
+  selector: 'z-calendar-grid',
+  template: `
+    <div #gridContainer>
+      <!-- Weekdays Header -->
+      <div class="grid w-fit grid-cols-7 text-center" role="row">
+        @for (weekday of weekdays; track weekday) {
+          <div [class]="weekdayClasses()" role="columnheader">
+            {{ weekday }}
+          </div>
+        }
+      </div>
+
+      <!-- Calendar Days Grid -->
+      <div class="mt-2 grid w-fit auto-rows-min grid-cols-7 gap-0" role="rowgroup">
+        @for (day of calendarDays(); track day.date.getTime(); let i = $index) {
+          <div [class]="dayContainerClasses()" role="gridcell">
+            <button
+              type="button"
+              [id]="getDayId(i)"
+              [class]="dayButtonClasses(day)"
+              (click)="onDayClick(day.date, i)"
+              [disabled]="day.isDisabled"
+              [attr.aria-selected]="day.isSelected"
+              [attr.aria-label]="getDayAriaLabel(day)"
+              [attr.tabindex]="getFocusedDayIndex() === i ? 0 : -1"
+              role="button"
+            >
+              {{ day.date.getDate() }}
+            </button>
+          </div>
+        }
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: 'flex justify-center',
+    '[attr.role]': '"grid"',
+    '(keydown.{arrowleft,arrowright,arrowup,arrowdown,home,end,pageup,pagedown,enter,space}.prevent)':
+      'onKeyDown($event)',
+  },
+  exportAs: 'zCalendarGrid',
+})
+export class ZardCalendarGridComponent {
+  private readonly gridContainer = viewChild.required<ElementRef<HTMLElement>>('gridContainer');
+
+  // Inputs
+  readonly calendarDays = input.required<CalendarDay[]>();
+  readonly disabled = input<boolean>(false);
+
+  // Outputs
+  readonly dateSelect = output<{ date: Date; index: number }>();
+  readonly previousMonth = output<{ position: string; dayOfWeek: number }>();
+  readonly nextMonth = output<{ position: string; dayOfWeek: number }>();
+  readonly navigateYear = output<number>();
+
+  readonly weekdays = calendarWeekdays;
+
+  private readonly focusedDayIndex = signal<number>(-1);
+
+  protected readonly weekdayClasses = computed(() => mergeClasses(calendarWeekdayVariants()));
+
+  protected readonly dayContainerClasses = computed(() => mergeClasses(calendarDayVariants()));
+
+  protected dayButtonClasses(day: CalendarDay): string {
+    return mergeClasses(
+      calendarDayButtonVariants({
+        selected: day.isSelected,
+        today: day.isToday,
+        outside: !day.isCurrentMonth,
+        disabled: day.isDisabled,
+        rangeStart: day.isRangeStart ?? false,
+        rangeEnd: day.isRangeEnd ?? false,
+        inRange: day.isInRange ?? false,
+      }),
+    );
+  }
+
+  protected onDayClick(date: Date, index: number): void {
+    if (this.disabled()) {
+      return;
+    }
+    this.focusedDayIndex.set(index);
+    this.dateSelect.emit({ date, index });
+  }
+
+  protected getDayId(index: number): string {
+    return getDayId(index);
+  }
+
+  protected getDayAriaLabel(day: CalendarDay): string {
+    return getDayAriaLabel(day);
+  }
+
+  protected getFocusedDayIndex(): number {
+    const focused = this.focusedDayIndex();
+    if (focused >= 0) {
+      return focused;
+    }
+
+    // Default focus to selected date or today
+    const days = this.calendarDays();
+    const selectedIndex = days.findIndex(day => day.isSelected);
+    if (selectedIndex >= 0) {
+      return selectedIndex;
+    }
+
+    const todayIndex = days.findIndex(day => day.isToday && day.isCurrentMonth);
+    if (todayIndex >= 0) {
+      return todayIndex;
+    }
+
+    // Fall back to first enabled day of current month
+    const firstCurrentMonthIndex = days.findIndex(day => day.isCurrentMonth && !day.isDisabled);
+    return firstCurrentMonthIndex >= 0 ? firstCurrentMonthIndex : 0;
+  }
+
+  /**
+   * Public method to set focus on a specific day index
+   */
+  setFocusedDayIndex(index: number): void {
+    this.focusedDayIndex.set(index);
+    this.setFocus(index);
+  }
+
+  /**
+   * Public method to reset focus based on priority
+   */
+  resetFocus(): void {
+    const targetIndex = this.getFocusedDayIndex();
+    this.setFocus(targetIndex);
+  }
+
+  onKeyDown(e: Event): void {
+    if (this.disabled()) {
+      return;
+    }
+
+    const event = e as KeyboardEvent;
+    const days = this.calendarDays();
+    if (days.length === 0) {
+      return;
+    }
+
+    const currentIndex = this.getFocusedDayIndex();
+    let newIndex: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        newIndex = this.navigate(currentIndex, -1, days);
+        break;
+      case 'ArrowRight':
+        newIndex = this.navigate(currentIndex, 1, days);
+        break;
+      case 'ArrowUp':
+        newIndex = this.navigate(currentIndex, -7, days);
+        break;
+      case 'ArrowDown':
+        newIndex = this.navigate(currentIndex, 7, days);
+        break;
+      case 'Home':
+        newIndex = this.findEnabledInRange(
+          Math.floor(currentIndex / 7) * 7,
+          Math.floor(currentIndex / 7) * 7 + 6,
+          days,
+        );
+        break;
+      case 'End':
+        newIndex = this.findEnabledInRange(
+          Math.floor(currentIndex / 7) * 7 + 6,
+          Math.floor(currentIndex / 7) * 7,
+          days,
+          true,
+        );
+        break;
+      case 'PageUp':
+        if (event.ctrlKey) {
+          this.navigateYear.emit(-1);
+        } else {
+          this.previousMonth.emit({ position: 'default', dayOfWeek: -1 });
+        }
+        break;
+      case 'PageDown':
+        if (event.ctrlKey) {
+          this.navigateYear.emit(1);
+        } else {
+          this.nextMonth.emit({ position: 'default', dayOfWeek: -1 });
+        }
+        break;
+      case 'Enter':
+      case ' ': {
+        const focusedDay = days[currentIndex];
+        if (focusedDay && !focusedDay.isDisabled) {
+          this.dateSelect.emit({ date: focusedDay.date, index: currentIndex });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    if (newIndex !== null && newIndex !== currentIndex) {
+      this.setFocus(newIndex);
+    }
+  }
+
+  private navigate(currentIndex: number, step: number, days: CalendarDay[]): number | null {
+    const targetIndex = currentIndex + step;
+
+    // If within bounds, find enabled day
+    if (targetIndex >= 0 && targetIndex < days.length) {
+      return this.findEnabledInRange(targetIndex, currentIndex, days);
+    }
+
+    // Handle month boundaries
+    const dayOfWeek = currentIndex % 7;
+
+    if (step === -1) {
+      // Going left - navigate to previous month, focus last day
+      this.previousMonth.emit({ position: 'last', dayOfWeek: -1 });
+    } else if (step === 1) {
+      // Going right - navigate to next month, focus first day
+      this.nextMonth.emit({ position: 'first', dayOfWeek: -1 });
+    } else if (step === -7) {
+      // Going up - navigate to previous month, preserve column
+      this.previousMonth.emit({ position: 'lastWeek', dayOfWeek });
+    } else if (step === 7) {
+      // Going down - navigate to next month, preserve column
+      this.nextMonth.emit({ position: 'firstWeek', dayOfWeek });
+    }
+
+    return null;
+  }
+
+  private findEnabledInRange(start: number, fallback: number, days: CalendarDay[], reverse = false): number {
+    const clampedStart = Math.max(0, Math.min(start, days.length - 1));
+    const clampedFallback = Math.max(0, Math.min(fallback, days.length - 1));
+
+    if (!reverse) {
+      // Search forward from start
+      for (let i = clampedStart; i < days.length; i++) {
+        if (!days[i].isDisabled) {
+          return i;
+        }
+      }
+      // Search backward from start
+      for (let i = clampedStart - 1; i >= 0; i--) {
+        if (!days[i].isDisabled) {
+          return i;
+        }
+      }
+    } else {
+      // Search backward from start
+      for (let i = clampedStart; i >= 0; i--) {
+        if (!days[i].isDisabled) {
+          return i;
+        }
+      }
+      // Search forward from start
+      for (let i = clampedStart + 1; i < days.length; i++) {
+        if (!days[i].isDisabled) {
+          return i;
+        }
+      }
+    }
+
+    return clampedFallback;
+  }
+
+  private setFocus(index: number): void {
+    this.focusedDayIndex.set(index);
+    setTimeout(() => {
+      const dayElement = this.gridContainer()?.nativeElement.querySelector(`#${getDayId(index)}`) as HTMLElement;
+      dayElement?.focus();
+    }, 0);
+  }
+}

--- a/v2/ui/calendar/calendar-navigation.component.ts
+++ b/v2/ui/calendar/calendar-navigation.component.ts
@@ -1,0 +1,181 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { ChangeDetectionStrategy, Component, computed, input, output, ViewEncapsulation } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronLeft, lucideChevronRight } from '@ng-icons/lucide';
+
+import { calendarMonths } from './calendar.utils';
+import { mergeClasses } from '../utils/merge-classes';
+
+import { calendarNavVariants } from './calendar.variants';
+import { ZardButtonComponent } from '../button/button.component';
+import { ZardSelectItemComponent } from '../select/select-item.component';
+import { ZardSelectComponent } from '../select/select.component';
+
+@Component({
+  selector: 'z-calendar-navigation',
+  imports: [ZardButtonComponent, NgIcon, ZardSelectComponent, ZardSelectItemComponent],
+  viewProviders: [provideIcons({ lucideChevronLeft, lucideChevronRight })],
+  template: `
+    <div [class]="navClasses()">
+      <button
+        type="button"
+        z-button
+        zType="ghost"
+        zSize="sm"
+        (click)="onPreviousClick()"
+        [disabled]="isPreviousDisabled()"
+        aria-label="Previous month"
+        class="size-7 p-0"
+      >
+        <ng-icon name="lucideChevronLeft" />
+      </button>
+
+      <!-- Month and Year Selectors -->
+      <div class="flex items-center space-x-2">
+        <!-- Month Select -->
+        <z-select [zValue]="currentMonth()" [zLabel]="currentMonthName()" (zSelectionChange)="onMonthChange($event)">
+          @for (month of months; track month) {
+            <z-select-item [zValue]="$index.toString()">{{ month }}</z-select-item>
+          }
+        </z-select>
+
+        <!-- Year Select -->
+        <z-select [zValue]="currentYear()" [zLabel]="currentYear()" (zSelectionChange)="onYearChange($event)">
+          @for (year of availableYears(); track year) {
+            <z-select-item [zValue]="year.toString()">{{ year }}</z-select-item>
+          }
+        </z-select>
+      </div>
+
+      <button
+        type="button"
+        z-button
+        zType="ghost"
+        zSize="sm"
+        (click)="onNextClick()"
+        [disabled]="isNextDisabled()"
+        aria-label="Next month"
+        class="size-7 p-0"
+      >
+        <ng-icon name="lucideChevronRight" />
+      </button>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zCalendarNavigation',
+})
+export class ZardCalendarNavigationComponent {
+  // Inputs
+  readonly currentMonth = input.required<string>();
+  readonly currentYear = input.required<string>();
+  readonly minDate = input<Date | null>(null);
+  readonly maxDate = input<Date | null>(null);
+  readonly disabled = input<boolean>(false);
+
+  // Outputs
+  readonly monthChange = output<string>();
+  readonly yearChange = output<string>();
+  readonly previousMonth = output<void>();
+  readonly nextMonth = output<void>();
+  readonly months = calendarMonths;
+
+  protected readonly navClasses = computed(() => mergeClasses(calendarNavVariants()));
+
+  protected readonly availableYears = computed(() => {
+    const minYear = this.minDate()?.getFullYear() ?? new Date().getFullYear() - 10;
+    const maxYear = this.maxDate()?.getFullYear() ?? new Date().getFullYear() + 10;
+    const years = [];
+    for (let i = minYear; i <= maxYear; i++) {
+      years.push(i);
+    }
+    return years;
+  });
+
+  protected readonly currentMonthName = computed(() => {
+    const selectedMonth = Number.parseInt(this.currentMonth());
+    if (!Number.isNaN(selectedMonth) && this.months[selectedMonth]) {
+      return this.months[selectedMonth];
+    }
+    return this.months[new Date().getMonth()];
+  });
+
+  protected readonly isPreviousDisabled = computed(() => {
+    if (this.disabled()) {
+      return true;
+    }
+
+    const minDate = this.minDate();
+    if (!minDate) {
+      return false;
+    }
+
+    const currentMonth = Number.parseInt(this.currentMonth());
+    const currentYear = Number.parseInt(this.currentYear());
+    const lastDayOfPreviousMonth = new Date(currentYear, currentMonth, 0);
+
+    return lastDayOfPreviousMonth.getTime() < minDate.getTime();
+  });
+
+  protected readonly isNextDisabled = computed(() => {
+    if (this.disabled()) {
+      return true;
+    }
+
+    const maxDate = this.maxDate();
+    if (!maxDate) {
+      return false;
+    }
+
+    const currentMonth = Number.parseInt(this.currentMonth());
+    const currentYear = Number.parseInt(this.currentYear());
+    const nextMonth = new Date(currentYear, currentMonth + 1, 1);
+
+    return nextMonth.getTime() > maxDate.getTime();
+  });
+
+  protected onPreviousClick(): void {
+    this.previousMonth.emit();
+  }
+
+  protected onNextClick(): void {
+    this.nextMonth.emit();
+  }
+
+  protected onMonthChange(month: string | string[]): void {
+    if (Array.isArray(month)) {
+      console.warn('Calendar navigation received array for month selection, expected single value. Ignoring:', month);
+      return;
+    }
+    this.monthChange.emit(month);
+  }
+
+  protected onYearChange(year: string | string[]): void {
+    if (Array.isArray(year)) {
+      console.warn('Calendar navigation received array for year selection, expected single value. Ignoring:', year);
+      return;
+    }
+    this.yearChange.emit(year);
+  }
+}

--- a/v2/ui/calendar/calendar-navigation.component.ts
+++ b/v2/ui/calendar/calendar-navigation.component.ts
@@ -134,8 +134,11 @@ export class ZardCalendarNavigationComponent {
     const currentMonth = Number.parseInt(this.currentMonth());
     const currentYear = Number.parseInt(this.currentYear());
     const lastDayOfPreviousMonth = new Date(currentYear, currentMonth, 0);
+    // Compare at day granularity so a min carrying a time-of-day doesn't
+    // disable a month that still contains the boundary day.
+    const min = new Date(minDate.getFullYear(), minDate.getMonth(), minDate.getDate());
 
-    return lastDayOfPreviousMonth.getTime() < minDate.getTime();
+    return lastDayOfPreviousMonth.getTime() < min.getTime();
   });
 
   protected readonly isNextDisabled = computed(() => {
@@ -151,8 +154,10 @@ export class ZardCalendarNavigationComponent {
     const currentMonth = Number.parseInt(this.currentMonth());
     const currentYear = Number.parseInt(this.currentYear());
     const nextMonth = new Date(currentYear, currentMonth + 1, 1);
+    // Compare at day granularity (ignore any time-of-day on the bound).
+    const max = new Date(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate());
 
-    return nextMonth.getTime() > maxDate.getTime();
+    return nextMonth.getTime() > max.getTime();
   });
 
   protected onPreviousClick(): void {

--- a/v2/ui/calendar/calendar.component.ts
+++ b/v2/ui/calendar/calendar.component.ts
@@ -356,8 +356,13 @@ export class ZardCalendarComponent implements ControlValueAccessor {
         const todayIndex = days.findIndex(day => day.isToday && day.isCurrentMonth);
         const firstEnabledIndex = days.findIndex(day => day.isCurrentMonth && !day.isDisabled);
 
-        targetIndex =
-          selectedIndex >= 0 ? selectedIndex : todayIndex >= 0 ? todayIndex : Math.max(firstEnabledIndex, 0);
+        if (selectedIndex >= 0) {
+          targetIndex = selectedIndex;
+        } else if (todayIndex >= 0) {
+          targetIndex = todayIndex;
+        } else {
+          targetIndex = Math.max(firstEnabledIndex, 0);
+        }
         break;
       }
     }

--- a/v2/ui/calendar/calendar.component.ts
+++ b/v2/ui/calendar/calendar.component.ts
@@ -300,12 +300,13 @@ export class ZardCalendarComponent implements ControlValueAccessor {
       } else if (selectedDates.length === 1) {
         // Second date selected - complete the range
         const start = selectedDates[0];
-        if (date.getTime() < start.getTime()) {
+        if (isSameDay(date, start)) {
+          // Same day clicked, reset (check first so a time-bearing start can't
+          // be mistaken for an earlier date on the same calendar day)
+          this.value.set(null);
+        } else if (date.getTime() < start.getTime()) {
           // New date is before start, swap them
           this.value.set([date, start]);
-        } else if (isSameDay(date, start)) {
-          // Same date clicked, reset
-          this.value.set(null);
         } else {
           // New date is after start
           this.value.set([start, date]);

--- a/v2/ui/calendar/calendar.component.ts
+++ b/v2/ui/calendar/calendar.component.ts
@@ -1,0 +1,405 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  forwardRef,
+  input,
+  linkedSignal,
+  model,
+  viewChild,
+  ViewEncapsulation,
+} from '@angular/core';
+import { outputFromObservable, outputToObservable } from '@angular/core/rxjs-interop';
+import { NG_VALUE_ACCESSOR, type ControlValueAccessor } from '@angular/forms';
+
+import type { ClassValue } from 'clsx';
+import { filter, map } from 'rxjs';
+
+import { ZardCalendarGridComponent } from './calendar-grid.component';
+import { ZardCalendarNavigationComponent } from './calendar-navigation.component';
+import type { CalendarMode, CalendarValue } from './calendar.types';
+import {
+  generateCalendarDays,
+  getSelectedDatesArray,
+  isSameDay,
+  makeSafeDate,
+  normalizeCalendarValue,
+} from './calendar.utils';
+import { calendarVariants } from './calendar.variants';
+import { mergeClasses, noopFn } from '../utils/merge-classes';
+
+@Component({
+  selector: 'z-calendar, [z-calendar]',
+  imports: [ZardCalendarNavigationComponent, ZardCalendarGridComponent],
+  template: `
+    <div [class]="classes()">
+      <z-calendar-navigation
+        [currentMonth]="currentMonthValue()"
+        [currentYear]="currentYearValue()"
+        [minDate]="minDate()"
+        [maxDate]="maxDate()"
+        [disabled]="disabled()"
+        (monthChange)="onMonthChange($event)"
+        (yearChange)="onYearChange($event)"
+        (previousMonth)="previousMonth()"
+        (nextMonth)="nextMonth()"
+      />
+
+      <z-calendar-grid
+        [calendarDays]="calendarDays()"
+        [disabled]="disabled()"
+        (dateSelect)="onDateSelect($event)"
+        (previousMonth)="onGridPreviousMonth($event)"
+        (nextMonth)="onGridNextMonth($event)"
+        (navigateYear)="onNavigateYear($event)"
+      />
+    </div>
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ZardCalendarComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[attr.tabindex]': '0',
+  },
+  exportAs: 'zCalendar',
+})
+export class ZardCalendarComponent implements ControlValueAccessor {
+  private readonly gridRef = viewChild.required(ZardCalendarGridComponent);
+
+  // Public method to reset navigation (useful for date-picker)
+  resetNavigation(): void {
+    const value = this.currentDate();
+    this.currentMonthValue.set(value.getMonth().toString());
+    this.currentYearValue.set(value.getFullYear().toString());
+    this.gridRef().setFocusedDayIndex(-1);
+  }
+
+  // Public inputs
+  readonly class = input<ClassValue>('');
+  readonly zMode = input<CalendarMode>('single');
+  readonly value = model<CalendarValue>(null);
+  readonly minDate = input<Date | null>(null);
+  readonly maxDate = input<Date | null>(null);
+  readonly disabled = model<boolean>(false);
+
+  // Public outputs
+  readonly dateChange = outputFromObservable(
+    outputToObservable(this.value).pipe(
+      map(v => normalizeCalendarValue(v)),
+      filter((v): v is NonNullable<CalendarValue> => v !== null),
+    ),
+  );
+
+  private onChange: (value: CalendarValue) => void = noopFn;
+  private onTouched: () => void = noopFn;
+
+  // Internal state
+  private readonly normalizedValue = computed(() => normalizeCalendarValue(this.value()));
+  private readonly currentDate = computed(() => {
+    const val = this.normalizedValue();
+    const mode = this.zMode();
+
+    if (!val) {
+      return new Date();
+    }
+
+    // For single mode, val is Date | null
+    if (mode === 'single') {
+      return val as Date;
+    }
+
+    // For multiple/range mode, val is Date[]
+    if (Array.isArray(val) && val.length > 0) {
+      return val[0];
+    }
+
+    return new Date();
+  });
+
+  protected readonly currentMonthValue = linkedSignal(() => this.currentDate().getMonth().toString());
+  protected readonly currentYearValue = linkedSignal(() => this.currentDate().getFullYear().toString());
+
+  protected readonly classes = computed(() => mergeClasses(calendarVariants(), this.class()));
+
+  protected readonly calendarDays = computed(() => {
+    const currentDate = this.currentDate();
+    const navigationDate = makeSafeDate(
+      Number.parseInt(this.currentYearValue()),
+      Number.parseInt(this.currentMonthValue()),
+      currentDate.getDate(),
+    );
+    const selectedDate = Number.isNaN(navigationDate.getTime()) ? currentDate : navigationDate;
+
+    return generateCalendarDays({
+      year: selectedDate.getFullYear(),
+      month: selectedDate.getMonth(),
+      mode: this.zMode(),
+      selectedDates: getSelectedDatesArray(this.normalizedValue(), this.zMode()),
+      minDate: this.minDate(),
+      maxDate: this.maxDate(),
+      disabled: this.disabled(),
+    });
+  });
+
+  protected onMonthChange(monthIndex: string | string[]): void {
+    if (Array.isArray(monthIndex)) {
+      console.warn('Calendar received array for month selection, expected single value. Ignoring:', monthIndex);
+      return;
+    }
+
+    if (!monthIndex?.trim()) {
+      console.warn('Invalid month index received:', monthIndex);
+      return;
+    }
+
+    const parsedMonth = Number.parseInt(monthIndex, 10);
+    if (Number.isNaN(parsedMonth) || parsedMonth < 0 || parsedMonth > 11) {
+      console.warn('Invalid month value:', monthIndex, 'parsed as:', parsedMonth);
+      return;
+    }
+
+    const currentDate = this.currentDate();
+    const selectedYear = Number.parseInt(this.currentYearValue());
+    const newDate = makeSafeDate(Number.isNaN(selectedYear) ? currentDate.getFullYear() : selectedYear, parsedMonth, 1);
+    this.currentMonthValue.set(newDate.getMonth().toString());
+    this.gridRef().setFocusedDayIndex(-1);
+  }
+
+  protected onYearChange(year: string | string[]): void {
+    if (Array.isArray(year)) {
+      console.warn('Calendar received array for year selection, expected single value. Ignoring:', year);
+      return;
+    }
+
+    if (!year?.trim()) {
+      console.warn('Invalid year received:', year);
+      return;
+    }
+
+    const parsedYear = Number.parseInt(year, 10);
+    if (Number.isNaN(parsedYear) || parsedYear < 1900 || parsedYear > 2100) {
+      console.warn('Invalid year value:', year, 'parsed as:', parsedYear);
+      return;
+    }
+
+    const currentDate = this.currentDate();
+    const selectedMonth = Number.parseInt(this.currentMonthValue());
+    const newDate = makeSafeDate(parsedYear, Number.isNaN(selectedMonth) ? currentDate.getMonth() : selectedMonth, 1);
+    this.currentYearValue.set(newDate.getFullYear().toString());
+    this.gridRef().setFocusedDayIndex(-1);
+  }
+
+  protected previousMonth(): void {
+    const month = Number.parseInt(this.currentMonthValue());
+    const year = Number.parseInt(this.currentYearValue());
+
+    const date = makeSafeDate(year, month - 1, 1);
+
+    this.currentMonthValue.set(date.getMonth().toString());
+    this.currentYearValue.set(date.getFullYear().toString());
+
+    this.gridRef().setFocusedDayIndex(-1);
+  }
+
+  protected nextMonth(): void {
+    const month = Number.parseInt(this.currentMonthValue());
+    const year = Number.parseInt(this.currentYearValue());
+
+    const date = makeSafeDate(year, month + 1, 1);
+
+    this.currentMonthValue.set(date.getMonth().toString());
+    this.currentYearValue.set(date.getFullYear().toString());
+
+    this.gridRef().setFocusedDayIndex(-1);
+  }
+
+  protected onNavigateYear(direction: number): void {
+    const current = this.currentDate();
+    const month = Number.parseInt(this.currentMonthValue());
+    const year = Number.parseInt(this.currentYearValue());
+    const baseYear = Number.isNaN(year) ? current.getFullYear() : year;
+    const baseMonth = Number.isNaN(month) ? current.getMonth() : month;
+    const newDate = makeSafeDate(baseYear + direction, baseMonth, 1);
+    this.currentYearValue.set(newDate.getFullYear().toString());
+    setTimeout(() => this.gridRef().resetFocus(), 0);
+  }
+
+  protected onGridPreviousMonth(event: { position: string; dayOfWeek: number }): void {
+    this.previousMonth();
+    setTimeout(() => this.resetFocusAfterNavigation(event.position, event.dayOfWeek), 0);
+  }
+
+  protected onGridNextMonth(event: { position: string; dayOfWeek: number }): void {
+    this.nextMonth();
+    setTimeout(() => this.resetFocusAfterNavigation(event.position, event.dayOfWeek), 0);
+  }
+
+  protected onDateSelect(event: { date: Date; index: number }): void {
+    this.selectDate(event.date);
+  }
+
+  private selectDate(date: Date): void {
+    if (this.disabled()) {
+      return;
+    }
+
+    const mode = this.zMode();
+    const currentValue = this.normalizedValue();
+
+    if (mode === 'single') {
+      this.value.set(date);
+    } else if (mode === 'multiple') {
+      const selectedDates = Array.isArray(currentValue) ? [...currentValue] : [];
+      const existingIndex = selectedDates.findIndex(d => isSameDay(d, date));
+
+      if (existingIndex >= 0) {
+        // Remove date if already selected
+        selectedDates.splice(existingIndex, 1);
+      } else {
+        // Add date
+        selectedDates.push(date);
+      }
+
+      this.value.set(selectedDates.length > 0 ? selectedDates : null);
+    } else if (mode === 'range') {
+      const selectedDates = Array.isArray(currentValue) ? [...currentValue] : [];
+
+      if (selectedDates.length === 0) {
+        // First date selected - set as range start
+        this.value.set([date]);
+      } else if (selectedDates.length === 1) {
+        // Second date selected - complete the range
+        const start = selectedDates[0];
+        if (date.getTime() < start.getTime()) {
+          // New date is before start, swap them
+          this.value.set([date, start]);
+        } else if (isSameDay(date, start)) {
+          // Same date clicked, reset
+          this.value.set(null);
+        } else {
+          // New date is after start
+          this.value.set([start, date]);
+        }
+      } else {
+        // Range already complete, start new range
+        this.value.set([date]);
+      }
+    }
+
+    this.onChange(this.normalizedValue());
+    this.onTouched();
+  }
+
+  private resetFocusAfterNavigation(position = 'default', dayOfWeek = -1): void {
+    const days = this.calendarDays();
+    let targetIndex = -1;
+
+    switch (position) {
+      case 'first':
+        // Focus first enabled day
+        targetIndex = days.findIndex(day => !day.isDisabled);
+        break;
+      case 'last':
+        // Focus last enabled day
+        for (let i = days.length - 1; i >= 0; i--) {
+          if (!days[i].isDisabled) {
+            targetIndex = i;
+            break;
+          }
+        }
+        break;
+      case 'firstWeek':
+        // Focus same day of week in first week
+        if (dayOfWeek >= 0 && dayOfWeek < 7) {
+          targetIndex = this.findEnabledInRange(dayOfWeek, 0, days);
+        }
+        break;
+      case 'lastWeek':
+        // Focus same day of week in last week
+        if (dayOfWeek >= 0) {
+          const lastWeekStart = Math.floor((days.length - 1) / 7) * 7;
+          const targetIdx = Math.min(lastWeekStart + dayOfWeek, days.length - 1);
+          targetIndex = this.findEnabledInRange(targetIdx, days.length - 1, days);
+        }
+        break;
+      default: {
+        // Default priority: selected > today > first enabled
+        const selectedIndex = days.findIndex(day => day.isSelected);
+        const todayIndex = days.findIndex(day => day.isToday && day.isCurrentMonth);
+        const firstEnabledIndex = days.findIndex(day => day.isCurrentMonth && !day.isDisabled);
+
+        targetIndex =
+          selectedIndex >= 0 ? selectedIndex : todayIndex >= 0 ? todayIndex : Math.max(firstEnabledIndex, 0);
+        break;
+      }
+    }
+
+    if (targetIndex >= 0) {
+      this.gridRef().setFocusedDayIndex(targetIndex);
+    }
+  }
+
+  private findEnabledInRange(start: number, fallback: number, days: { isDisabled: boolean }[]): number {
+    const clampedStart = Math.max(0, Math.min(start, days.length - 1));
+    const clampedFallback = Math.max(0, Math.min(fallback, days.length - 1));
+
+    // Search forward from start
+    for (let i = clampedStart; i < days.length; i++) {
+      if (!days[i].isDisabled) {
+        return i;
+      }
+    }
+    // Search backward from start
+    for (let i = clampedStart - 1; i >= 0; i--) {
+      if (!days[i].isDisabled) {
+        return i;
+      }
+    }
+
+    return clampedFallback;
+  }
+
+  writeValue(value: CalendarValue): void {
+    this.value.set(value);
+  }
+
+  registerOnChange(fn: (value: CalendarValue) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled.set(isDisabled);
+  }
+}

--- a/v2/ui/calendar/calendar.component.ts
+++ b/v2/ui/calendar/calendar.component.ts
@@ -154,7 +154,9 @@ export class ZardCalendarComponent implements ControlValueAccessor {
     const navigationDate = makeSafeDate(
       Number.parseInt(this.currentYearValue()),
       Number.parseInt(this.currentMonthValue()),
-      currentDate.getDate(),
+      // Anchor to day 1: only the year/month are used below, and a 29th-31st
+      // day would overflow into the next month for shorter months.
+      1,
     );
     const selectedDate = Number.isNaN(navigationDate.getTime()) ? currentDate : navigationDate;
 

--- a/v2/ui/calendar/calendar.types.ts
+++ b/v2/ui/calendar/calendar.types.ts
@@ -20,16 +20,27 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './calendar';
-export * from './date-picker';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './popover';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+export type CalendarMode = 'single' | 'multiple' | 'range';
+export type CalendarValue = Date | Date[] | null;
+
+export interface CalendarDay {
+  date: Date;
+  isCurrentMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  isDisabled: boolean;
+  isRangeStart?: boolean;
+  isRangeEnd?: boolean;
+  isInRange?: boolean;
+  id?: string;
+}
+
+export interface CalendarDayConfig {
+  year: number;
+  month: number;
+  mode: CalendarMode;
+  selectedDates: Date[];
+  minDate: Date | null;
+  maxDate: Date | null;
+  disabled: boolean;
+}

--- a/v2/ui/calendar/calendar.utils.ts
+++ b/v2/ui/calendar/calendar.utils.ts
@@ -54,8 +54,20 @@ export function isSameDay(date1: Date, date2: Date): boolean {
  * Checks if a date is disabled based on min/max constraints
  */
 export function isDateDisabled(date: Date, minDate: Date | null, maxDate: Date | null): boolean {
-  if ((minDate && date < minDate) || (maxDate && date > maxDate)) {
-    return true;
+  // Compare at day granularity so a min/max carrying a time-of-day does not
+  // disable its own calendar day.
+  const day = makeSafeDate(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+  if (minDate) {
+    const min = makeSafeDate(minDate.getFullYear(), minDate.getMonth(), minDate.getDate()).getTime();
+    if (day < min) {
+      return true;
+    }
+  }
+  if (maxDate) {
+    const max = makeSafeDate(maxDate.getFullYear(), maxDate.getMonth(), maxDate.getDate()).getTime();
+    if (day > max) {
+      return true;
+    }
   }
   return false;
 }
@@ -208,6 +220,18 @@ export function makeSafeDate(year: number, month: number, day = 1): Date {
 }
 
 /**
+ * Like makeSafeDate, but returns null when the parsed y/m/d do not survive the
+ * Date construction (e.g. 2024-02-31 would silently roll forward to March).
+ */
+export function makeStrictDate(year: number, month: number, day: number): Date | null {
+  const date = makeSafeDate(year, month, day);
+  if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
+    return null;
+  }
+  return date;
+}
+
+/**
  * Normalizes any calendar value into a valid Date or array of Dates.
  * Returns null for empty values, validates single Dates, converts arrays,
  * and attempts to parse any other type into a Date.
@@ -250,7 +274,7 @@ export function toValidDate(value: unknown): Date | null {
     const m = +s.slice(4, 6) - 1;
     const d = +s.slice(6, 8);
 
-    return makeSafeDate(y, m, d);
+    return makeStrictDate(y, m, d);
   }
 
   if (typeof value === 'string' && /^\d{8}$/.test(value)) {
@@ -258,7 +282,7 @@ export function toValidDate(value: unknown): Date | null {
     const m = +value.slice(4, 6) - 1;
     const d = +value.slice(6, 8);
 
-    return makeSafeDate(y, m, d);
+    return makeStrictDate(y, m, d);
   }
 
   const date = new Date(value as string | number | Date);

--- a/v2/ui/calendar/calendar.utils.ts
+++ b/v2/ui/calendar/calendar.utils.ts
@@ -1,0 +1,271 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import type { CalendarDay, CalendarDayConfig, CalendarMode, CalendarValue } from './calendar.types';
+
+export const calendarMonths = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+] as const;
+
+export const calendarWeekdays = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const;
+
+/**
+ * Checks if two dates represent the same day (ignoring time)
+ */
+export function isSameDay(date1: Date, date2: Date): boolean {
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+}
+
+/**
+ * Checks if a date is disabled based on min/max constraints
+ */
+export function isDateDisabled(date: Date, minDate: Date | null, maxDate: Date | null): boolean {
+  if ((minDate && date < minDate) || (maxDate && date > maxDate)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Generates calendar days for a given month with all selection states
+ */
+export function generateCalendarDays(config: CalendarDayConfig): CalendarDay[] {
+  const { year, month, mode, selectedDates, minDate, maxDate, disabled } = config;
+
+  const today = new Date();
+
+  // Get first day of the month
+  const firstDay = new Date(year, month, 1);
+  // Get last day of the month
+  const lastDay = new Date(year, month + 1, 0);
+
+  // Get the first day of the week for the first day of the month
+  const startDate = new Date(firstDay);
+  startDate.setDate(startDate.getDate() - startDate.getDay());
+
+  // Get the last day of the week for the last day of the month
+  const endDate = new Date(lastDay);
+  endDate.setDate(endDate.getDate() + (6 - endDate.getDay()));
+
+  const days: CalendarDay[] = [];
+  const currentWeekDate = new Date(startDate);
+
+  // For range mode, determine range start and end
+  let rangeStart: Date | null = null;
+  let rangeEnd: Date | null = null;
+  if (mode === 'range' && selectedDates.length > 0) {
+    rangeStart = selectedDates[0];
+    rangeEnd = selectedDates.length > 1 ? selectedDates[1] : null;
+  }
+
+  while (currentWeekDate <= endDate) {
+    const date = new Date(currentWeekDate);
+    const isCurrentMonth = date.getMonth() === month;
+    const isToday = isSameDay(date, today);
+    const isDisabledDate = disabled || isDateDisabled(date, minDate, maxDate);
+
+    // Determine if date is selected
+    let isSelected = false;
+    let isRangeStart = false;
+    let isRangeEnd = false;
+    let isInRange = false;
+
+    if (mode === 'single') {
+      isSelected = selectedDates.length > 0 && isSameDay(date, selectedDates[0]);
+    } else if (mode === 'multiple') {
+      isSelected = selectedDates.some(d => isSameDay(date, d));
+    } else if (mode === 'range') {
+      if (rangeStart && isSameDay(date, rangeStart)) {
+        isRangeStart = true;
+        isSelected = true;
+      }
+      if (rangeEnd && isSameDay(date, rangeEnd)) {
+        isRangeEnd = true;
+        isSelected = true;
+      }
+      if (rangeStart && rangeEnd && !isRangeStart && !isRangeEnd) {
+        // Check if date is between start and end
+        const dateTime = date.getTime();
+        const startTime = rangeStart.getTime();
+        const endTime = rangeEnd.getTime();
+        isInRange = dateTime > startTime && dateTime < endTime;
+      }
+    }
+
+    days.push({
+      date,
+      isCurrentMonth,
+      isToday,
+      isSelected,
+      isDisabled: isDisabledDate,
+      isRangeStart,
+      isRangeEnd,
+      isInRange,
+    });
+
+    currentWeekDate.setDate(currentWeekDate.getDate() + 1);
+  }
+
+  return days;
+}
+
+/**
+ * Converts CalendarValue to array of Dates for easier processing
+ */
+export function getSelectedDatesArray(value: CalendarValue, mode: CalendarMode): Date[] {
+  if (!value) {
+    return [];
+  }
+
+  if (mode === 'single') {
+    return [value as Date];
+  }
+
+  if ((mode === 'multiple' || mode === 'range') && Array.isArray(value)) {
+    return value;
+  }
+
+  return [];
+}
+
+/**
+ * Generates a unique ID for a calendar day
+ */
+export function getDayId(index: number): string {
+  return `calendar-day-${index}`;
+}
+
+/**
+ * Generates an accessible ARIA label for a calendar day
+ */
+export function getDayAriaLabel(day: CalendarDay): string {
+  const dateStr = day.date.toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  const labels = [
+    dateStr,
+    day.isToday && 'Today',
+    day.isSelected && 'Selected',
+    day.isRangeStart && 'Range start',
+    day.isRangeEnd && 'Range end',
+    day.isInRange && 'In range',
+    !day.isCurrentMonth && 'Outside month',
+    day.isDisabled && 'Disabled',
+  ].filter(Boolean);
+
+  return labels.join(', ');
+}
+
+/**
+ * Creates a date positioned safely at midday to avoid timezone-based
+ * month/day shifts triggered by local DST or UTC conversions.
+ *
+ * Useful when constructing calendar/navigation dates where 00:00
+ * may incorrectly roll the date backward or forward.
+ */
+export function makeSafeDate(year: number, month: number, day = 1): Date {
+  const date = new Date(year, month, day);
+  date.setHours(12, 0, 0, 0);
+  return date;
+}
+
+/**
+ * Normalizes any calendar value into a valid Date or array of Dates.
+ * Returns null for empty values, validates single Dates, converts arrays,
+ * and attempts to parse any other type into a Date.
+ */
+export function normalizeCalendarValue(v: CalendarValue): CalendarValue {
+  if (!v) {
+    return v;
+  }
+
+  if (v instanceof Date) {
+    return toValidDate(v);
+  }
+
+  if (Array.isArray(v)) {
+    return v.reduce<Date[]>((acc, d) => {
+      const date = toValidDate(d);
+      if (date) {
+        acc.push(date);
+      }
+      return acc;
+    }, []);
+  }
+
+  return toValidDate(v);
+}
+
+/**
+ * Converts any value into a valid Date.
+ * If it is already a Date, it is returned as is.
+ * If the conversion fails, null should be returned.
+ */
+export function toValidDate(value: unknown): Date | null {
+  if (value instanceof Date) {
+    return isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === 'number' && value.toString().length === 8) {
+    const s = value.toString();
+    const y = +s.slice(0, 4);
+    const m = +s.slice(4, 6) - 1;
+    const d = +s.slice(6, 8);
+
+    return makeSafeDate(y, m, d);
+  }
+
+  if (typeof value === 'string' && /^\d{8}$/.test(value)) {
+    const y = +value.slice(0, 4);
+    const m = +value.slice(4, 6) - 1;
+    const d = +value.slice(6, 8);
+
+    return makeSafeDate(y, m, d);
+  }
+
+  const date = new Date(value as string | number | Date);
+
+  if (isNaN(date.getTime())) {
+    return null;
+  }
+
+  return makeSafeDate(date.getFullYear(), date.getMonth(), date.getDate());
+}

--- a/v2/ui/calendar/calendar.utils.ts
+++ b/v2/ui/calendar/calendar.utils.ts
@@ -241,7 +241,7 @@ export function normalizeCalendarValue(v: CalendarValue): CalendarValue {
  */
 export function toValidDate(value: unknown): Date | null {
   if (value instanceof Date) {
-    return isNaN(value.getTime()) ? null : value;
+    return Number.isNaN(value.getTime()) ? null : value;
   }
 
   if (typeof value === 'number' && value.toString().length === 8) {
@@ -263,7 +263,7 @@ export function toValidDate(value: unknown): Date | null {
 
   const date = new Date(value as string | number | Date);
 
-  if (isNaN(date.getTime())) {
+  if (Number.isNaN(date.getTime())) {
     return null;
   }
 

--- a/v2/ui/calendar/calendar.variants.ts
+++ b/v2/ui/calendar/calendar.variants.ts
@@ -1,0 +1,106 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva } from 'class-variance-authority';
+
+export const calendarVariants = cva('bg-background p-3 w-fit rounded-lg border');
+
+export const calendarMonthVariants = cva('flex flex-col w-fit gap-4');
+
+export const calendarNavVariants = cva('flex items-center justify-between gap-2 w-fit mb-4');
+
+export const calendarNavButtonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground size-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+);
+
+export const calendarWeekdaysVariants = cva('flex');
+
+export const calendarWeekdayVariants = cva('text-muted-foreground font-normal text-center text-[0.8rem] w-8');
+
+export const calendarWeekVariants = cva('flex w-full mt-2');
+
+export const calendarDayVariants = cva('p-0 relative focus-within:relative focus-within:z-20 flex mt-1 size-8 text-sm');
+
+export const calendarDayButtonVariants = cva(
+  'p-0 font-normal flex items-center justify-center whitespace-nowrap rounded-md ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground size-full text-sm',
+  {
+    variants: {
+      selected: {
+        true: 'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+        false: '',
+      },
+      today: {
+        true: 'bg-accent text-accent-foreground',
+        false: '',
+      },
+      outside: {
+        true: 'text-muted-foreground opacity-50',
+        false: '',
+      },
+      disabled: {
+        true: 'text-muted-foreground opacity-50 cursor-not-allowed',
+        false: '',
+      },
+      rangeStart: {
+        true: 'rounded-r-none bg-primary text-primary-foreground',
+        false: '',
+      },
+      rangeEnd: {
+        true: 'rounded-l-none bg-primary text-primary-foreground',
+        false: '',
+      },
+      inRange: {
+        true: 'rounded-none bg-accent hover:bg-accent',
+        false: '',
+      },
+    },
+    compoundVariants: [
+      {
+        today: true,
+        selected: false,
+        rangeStart: false,
+        rangeEnd: false,
+        inRange: false,
+        className: 'bg-accent text-accent-foreground',
+      },
+      {
+        today: true,
+        selected: true,
+        className: 'bg-primary text-primary-foreground',
+      },
+      {
+        rangeStart: true,
+        rangeEnd: true,
+        className: 'rounded-md bg-primary text-primary-foreground',
+      },
+    ],
+    defaultVariants: {
+      selected: false,
+      today: false,
+      outside: false,
+      disabled: false,
+      rangeStart: false,
+      rangeEnd: false,
+      inRange: false,
+    },
+  },
+);

--- a/v2/ui/calendar/index.ts
+++ b/v2/ui/calendar/index.ts
@@ -20,16 +20,9 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './calendar';
-export * from './date-picker';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './popover';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+export * from './calendar.component';
+export * from './calendar.variants';
+export * from './calendar.types';
+export * from './calendar.utils';
+export * from './calendar-grid.component';
+export * from './calendar-navigation.component';

--- a/v2/ui/date-picker/date-picker.component.ts
+++ b/v2/ui/date-picker/date-picker.component.ts
@@ -1,0 +1,213 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  forwardRef,
+  inject,
+  input,
+  model,
+  output,
+  viewChild,
+  ViewEncapsulation,
+  type TemplateRef,
+} from '@angular/core';
+import { NG_VALUE_ACCESSOR, type ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCalendar } from '@ng-icons/lucide';
+
+import type { ClassValue } from 'clsx';
+
+import { ZardButtonComponent, type ZardButtonTypeVariants } from '../button';
+import { ZardCalendarComponent } from '../calendar';
+import type { ZardDatePickerSizeVariants } from './date-picker.variants';
+import { ZardPopoverComponent, ZardPopoverDirective } from '../popover';
+import { mergeClasses, noopFn } from '../utils/merge-classes';
+
+/**
+ * Height overrides for date-picker sizes.
+ *
+ * These heights intentionally differ from button size variants to accommodate
+ * the date-picker UI:
+ * - default: h-9 (vs button h-8)
+ * - lg: h-11 (vs button h-9)
+ *
+ * The `mergeClasses` utility (tailwind-merge) resolves class conflicts,
+ * allowing these values to override the base button heights defined in
+ * `ZardDatePickerSizeVariants`.
+ */
+const HEIGHT_BY_SIZE: Record<ZardDatePickerSizeVariants, string> = {
+  xs: 'h-7',
+  sm: 'h-8',
+  default: 'h-9',
+  lg: 'h-11',
+};
+
+@Component({
+  selector: 'z-date-picker, [z-date-picker]',
+  imports: [ZardButtonComponent, ZardCalendarComponent, ZardPopoverComponent, ZardPopoverDirective, NgIcon],
+  viewProviders: [provideIcons({ lucideCalendar })],
+  template: `
+    <button
+      z-button
+      type="button"
+      [zType]="zType()"
+      [zSize]="zSize()"
+      [disabled]="disabled()"
+      [class]="buttonClasses()"
+      zPopover
+      #popoverDirective="zPopover"
+      [zContent]="calendarTemplate"
+      zTrigger="click"
+      (zVisibleChange)="onPopoverVisibilityChange($event)"
+      [attr.aria-expanded]="false"
+      [attr.aria-haspopup]="true"
+      aria-label="Choose date"
+    >
+      <ng-icon name="lucideCalendar" />
+      <span [class]="textClasses()">
+        {{ displayText() }}
+      </span>
+    </button>
+
+    <ng-template #calendarTemplate>
+      <z-popover [class]="popoverClasses()">
+        <z-calendar
+          #calendar
+          class="border-0"
+          [value]="value()"
+          [minDate]="minDate()"
+          [maxDate]="maxDate()"
+          [disabled]="disabled()"
+          (dateChange)="onDateChange($event)"
+        />
+      </z-popover>
+    </ng-template>
+  `,
+  providers: [
+    DatePipe,
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ZardDatePickerComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'class()',
+  },
+  exportAs: 'zDatePicker',
+})
+export class ZardDatePickerComponent implements ControlValueAccessor {
+  private readonly datePipe = inject(DatePipe);
+
+  readonly calendarTemplate = viewChild.required<TemplateRef<unknown>>('calendarTemplate');
+  readonly popoverDirective = viewChild.required<ZardPopoverDirective>('popoverDirective');
+  readonly calendar = viewChild.required<ZardCalendarComponent>('calendar');
+
+  readonly class = input<ClassValue>('');
+  readonly zType = input<ZardButtonTypeVariants>('outline');
+  readonly zSize = input<ZardDatePickerSizeVariants>('default');
+  readonly value = model<Date | null>(null);
+  readonly placeholder = input<string>('Pick a date');
+  readonly zFormat = input<string>('MMMM d, yyyy');
+  readonly minDate = input<Date | null>(null);
+  readonly maxDate = input<Date | null>(null);
+  readonly disabled = model<boolean>(false);
+
+  readonly dateChange = output<Date | null>();
+
+  private onChange: (value: Date | null) => void = noopFn;
+  private onTouched: () => void = noopFn;
+
+  protected readonly buttonClasses = computed(() => {
+    const hasValue = !!this.value();
+    const size = this.zSize();
+    const height = HEIGHT_BY_SIZE[size];
+    return mergeClasses(
+      'justify-start text-left font-normal',
+      !hasValue && 'text-muted-foreground',
+      height,
+      'min-w-[240px]',
+    );
+  });
+
+  protected readonly textClasses = computed(() => {
+    const hasValue = !!this.value();
+    return mergeClasses(!hasValue && 'text-muted-foreground');
+  });
+
+  protected readonly popoverClasses = computed(() => mergeClasses('w-auto p-0'));
+
+  protected readonly displayText = computed(() => {
+    const date = this.value();
+    if (!date) {
+      return this.placeholder();
+    }
+    return this.formatDate(date, this.zFormat());
+  });
+
+  protected onDateChange(date: Date | Date[]): void {
+    // Date picker always uses single mode, so we can safely cast
+    const singleDate = Array.isArray(date) ? (date[0] ?? null) : date;
+    this.value.set(singleDate);
+    this.onChange(singleDate);
+    this.onTouched();
+    this.dateChange.emit(singleDate);
+
+    this.popoverDirective().hide();
+  }
+
+  protected onPopoverVisibilityChange(visible: boolean): void {
+    if (visible) {
+      setTimeout(() => {
+        if (this.calendar()) {
+          this.calendar().resetNavigation();
+        }
+      });
+    }
+  }
+
+  private formatDate(date: Date, format: string): string {
+    return this.datePipe.transform(date, format) ?? '';
+  }
+
+  writeValue(value: Date | null): void {
+    this.value.set(value);
+  }
+
+  registerOnChange(fn: (value: Date | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled.set(isDisabled);
+  }
+}

--- a/v2/ui/date-picker/date-picker.component.ts
+++ b/v2/ui/date-picker/date-picker.component.ts
@@ -126,7 +126,7 @@ export class ZardDatePickerComponent implements ControlValueAccessor {
 
   readonly calendarTemplate = viewChild.required<TemplateRef<unknown>>('calendarTemplate');
   readonly popoverDirective = viewChild.required<ZardPopoverDirective>('popoverDirective');
-  readonly calendar = viewChild.required<ZardCalendarComponent>('calendar');
+  readonly calendar = viewChild<ZardCalendarComponent>('calendar');
 
   readonly class = input<ClassValue>('');
   readonly zType = input<ZardButtonTypeVariants>('outline');
@@ -183,11 +183,12 @@ export class ZardDatePickerComponent implements ControlValueAccessor {
 
   protected onPopoverVisibilityChange(visible: boolean): void {
     if (visible) {
-      setTimeout(() => {
-        if (this.calendar()) {
-          this.calendar().resetNavigation();
-        }
-      });
+      // Optional query + optional chaining: the popover content may be torn
+      // down before this runs.
+      setTimeout(() => this.calendar()?.resetNavigation());
+    } else {
+      // Closing without a selection should still mark the control touched.
+      this.onTouched();
     }
   }
 

--- a/v2/ui/date-picker/date-picker.component.ts
+++ b/v2/ui/date-picker/date-picker.component.ts
@@ -30,6 +30,7 @@ import {
   input,
   model,
   output,
+  signal,
   viewChild,
   ViewEncapsulation,
   type TemplateRef,
@@ -82,7 +83,7 @@ const HEIGHT_BY_SIZE: Record<ZardDatePickerSizeVariants, string> = {
       [zContent]="calendarTemplate"
       zTrigger="click"
       (zVisibleChange)="onPopoverVisibilityChange($event)"
-      [attr.aria-expanded]="false"
+      [attr.aria-expanded]="isOpen()"
       [attr.aria-haspopup]="true"
       aria-label="Choose date"
     >
@@ -181,7 +182,10 @@ export class ZardDatePickerComponent implements ControlValueAccessor {
     this.popoverDirective().hide();
   }
 
+  protected readonly isOpen = signal(false);
+
   protected onPopoverVisibilityChange(visible: boolean): void {
+    this.isOpen.set(visible);
     if (visible) {
       // Optional query + optional chaining: the popover content may be torn
       // down before this runs.

--- a/v2/ui/date-picker/date-picker.variants.ts
+++ b/v2/ui/date-picker/date-picker.variants.ts
@@ -20,16 +20,26 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './calendar';
-export * from './date-picker';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './popover';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const datePickerVariants = cva('', {
+  variants: {
+    zSize: {
+      xs: '',
+      sm: '',
+      default: '',
+      lg: '',
+    },
+    zType: {
+      default: '',
+      outline: '',
+      ghost: '',
+    },
+  },
+  defaultVariants: {
+    zSize: 'default',
+    zType: 'outline',
+  },
+});
+
+export type ZardDatePickerSizeVariants = NonNullable<VariantProps<typeof datePickerVariants>['zSize']>;

--- a/v2/ui/date-picker/index.ts
+++ b/v2/ui/date-picker/index.ts
@@ -20,16 +20,5 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './calendar';
-export * from './date-picker';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './popover';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+export * from './date-picker.component';
+export * from './date-picker.variants';

--- a/v2/ui/popover/index.ts
+++ b/v2/ui/popover/index.ts
@@ -20,16 +20,5 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './calendar';
-export * from './date-picker';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './popover';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+export * from './popover.component';
+export * from './popover.variants';

--- a/v2/ui/popover/popover.component.ts
+++ b/v2/ui/popover/popover.component.ts
@@ -229,9 +229,10 @@ export class ZardPopoverDirective implements OnInit, OnDestroy {
     if (trigger === 'click') {
       this.listeners.push(this.renderer.listen(this.nativeElement, 'click.stop', () => this.toggle()));
     } else if (trigger === 'hover') {
-      this.listeners.push(this.renderer.listen(this.nativeElement, 'mouseenter', () => this.show()));
-
-      this.listeners.push(this.renderer.listen(this.nativeElement, 'mouseleave', () => this.hide()));
+      this.listeners.push(
+        this.renderer.listen(this.nativeElement, 'mouseenter', () => this.show()),
+        this.renderer.listen(this.nativeElement, 'mouseleave', () => this.hide()),
+      );
     }
   }
 
@@ -260,120 +261,44 @@ export class ZardPopoverDirective implements OnInit, OnDestroy {
     // Fallback positions for better positioning when primary doesn't fit
     switch (placement) {
       case 'bottom':
-        // Try top if bottom doesn't fit
-        positions.push({
-          originX: 'center',
-          originY: 'top',
-          overlayX: 'center',
-          overlayY: 'bottom',
-          offsetX: 0,
-          offsetY: -8,
-        });
-        // If neither top nor bottom work, try right
-        positions.push({
-          originX: 'end',
-          originY: 'center',
-          overlayX: 'start',
-          overlayY: 'center',
-          offsetX: 8,
-          offsetY: 0,
-        });
-        // Finally try left
-        positions.push({
-          originX: 'start',
-          originY: 'center',
-          overlayX: 'end',
-          overlayY: 'center',
-          offsetX: -8,
-          offsetY: 0,
-        });
+        positions.push(
+          // Try top if bottom doesn't fit
+          { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom', offsetX: 0, offsetY: -8 },
+          // If neither top nor bottom work, try right
+          { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: 8, offsetY: 0 },
+          // Finally try left
+          { originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -8, offsetY: 0 },
+        );
         break;
       case 'top':
-        // Try bottom if top doesn't fit
-        positions.push({
-          originX: 'center',
-          originY: 'bottom',
-          overlayX: 'center',
-          overlayY: 'top',
-          offsetX: 0,
-          offsetY: 8,
-        });
-        // If neither top nor bottom work, try right
-        positions.push({
-          originX: 'end',
-          originY: 'center',
-          overlayX: 'start',
-          overlayY: 'center',
-          offsetX: 8,
-          offsetY: 0,
-        });
-        // Finally try left
-        positions.push({
-          originX: 'start',
-          originY: 'center',
-          overlayX: 'end',
-          overlayY: 'center',
-          offsetX: -8,
-          offsetY: 0,
-        });
+        positions.push(
+          // Try bottom if top doesn't fit
+          { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top', offsetX: 0, offsetY: 8 },
+          // If neither top nor bottom work, try right
+          { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: 8, offsetY: 0 },
+          // Finally try left
+          { originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -8, offsetY: 0 },
+        );
         break;
       case 'right':
-        // Try left if right doesn't fit
-        positions.push({
-          originX: 'start',
-          originY: 'center',
-          overlayX: 'end',
-          overlayY: 'center',
-          offsetX: -8,
-          offsetY: 0,
-        });
-        // If neither left nor right work, try bottom
-        positions.push({
-          originX: 'center',
-          originY: 'bottom',
-          overlayX: 'center',
-          overlayY: 'top',
-          offsetX: 0,
-          offsetY: 8,
-        });
-        // Finally try top
-        positions.push({
-          originX: 'center',
-          originY: 'top',
-          overlayX: 'center',
-          overlayY: 'bottom',
-          offsetX: 0,
-          offsetY: -8,
-        });
+        positions.push(
+          // Try left if right doesn't fit
+          { originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -8, offsetY: 0 },
+          // If neither left nor right work, try bottom
+          { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top', offsetX: 0, offsetY: 8 },
+          // Finally try top
+          { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom', offsetX: 0, offsetY: -8 },
+        );
         break;
       case 'left':
-        // Try right if left doesn't fit
-        positions.push({
-          originX: 'end',
-          originY: 'center',
-          overlayX: 'start',
-          overlayY: 'center',
-          offsetX: 8,
-          offsetY: 0,
-        });
-        // If neither left nor right work, try bottom
-        positions.push({
-          originX: 'center',
-          originY: 'bottom',
-          overlayX: 'center',
-          overlayY: 'top',
-          offsetX: 0,
-          offsetY: 8,
-        });
-        // Finally try top
-        positions.push({
-          originX: 'center',
-          originY: 'top',
-          overlayX: 'center',
-          overlayY: 'bottom',
-          offsetX: 0,
-          offsetY: -8,
-        });
+        positions.push(
+          // Try right if left doesn't fit
+          { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: 8, offsetY: 0 },
+          // If neither left nor right work, try bottom
+          { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top', offsetX: 0, offsetY: 8 },
+          // Finally try top
+          { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom', offsetX: 0, offsetY: -8 },
+        );
         break;
     }
 

--- a/v2/ui/popover/popover.component.ts
+++ b/v2/ui/popover/popover.component.ts
@@ -1,0 +1,400 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { type ConnectedPosition, Overlay, OverlayPositionBuilder, type OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { isPlatformBrowser } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  type OnDestroy,
+  type OnInit,
+  output,
+  PLATFORM_ID,
+  Renderer2,
+  signal,
+  type TemplateRef,
+  ViewContainerRef,
+} from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+
+import { filter, type Subscription } from 'rxjs';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import { popoverVariants } from './popover.variants';
+
+export type ZardPopoverTrigger = 'click' | 'hover' | null;
+export type ZardPopoverPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+const POPOVER_POSITIONS_MAP: { [key: string]: ConnectedPosition } = {
+  top: {
+    originX: 'center',
+    originY: 'top',
+    overlayX: 'center',
+    overlayY: 'bottom',
+    offsetX: 0,
+    offsetY: -8,
+  },
+  bottom: {
+    originX: 'center',
+    originY: 'bottom',
+    overlayX: 'center',
+    overlayY: 'top',
+    offsetX: 0,
+    offsetY: 8,
+  },
+  left: {
+    originX: 'start',
+    originY: 'center',
+    overlayX: 'end',
+    overlayY: 'center',
+    offsetX: -8,
+    offsetY: 0,
+  },
+  right: {
+    originX: 'end',
+    originY: 'center',
+    overlayX: 'start',
+    overlayY: 'center',
+    offsetX: 8,
+    offsetY: 0,
+  },
+} as const;
+
+@Directive({
+  selector: '[zPopover]',
+  standalone: true,
+  exportAs: 'zPopover',
+})
+export class ZardPopoverDirective implements OnInit, OnDestroy {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly overlay = inject(Overlay);
+  private readonly overlayPositionBuilder = inject(OverlayPositionBuilder);
+  private readonly elementRef = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
+  private readonly viewContainerRef = inject(ViewContainerRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  private overlayRef?: OverlayRef;
+  private overlayRefSubscription?: Subscription;
+  private listeners: (() => void)[] = [];
+
+  readonly zTrigger = input<ZardPopoverTrigger>('click');
+  readonly zContent = input.required<TemplateRef<unknown>>();
+  readonly zPlacement = input<ZardPopoverPlacement>('bottom');
+  readonly zOrigin = input<ElementRef>();
+  readonly zVisible = input<boolean>(false);
+  readonly zOverlayClickable = input<boolean>(true);
+  readonly zVisibleChange = output<boolean>();
+
+  private readonly isVisible = signal(false);
+
+  get nativeElement() {
+    return this.zOrigin()?.nativeElement ?? this.elementRef.nativeElement;
+  }
+
+  constructor() {
+    toObservable(this.zVisible)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(visible => {
+        const currentlyVisible = this.isVisible();
+        if (visible && !currentlyVisible) {
+          this.show();
+        } else if (!visible && currentlyVisible) {
+          this.hide();
+        }
+      });
+
+    toObservable(this.zTrigger)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(trigger => {
+        if (this.listeners.length) {
+          this.unlistenAll();
+        }
+        this.setupTriggers();
+        this.overlayRefSubscription?.unsubscribe();
+        this.overlayRefSubscription = undefined;
+        if (trigger === 'click') {
+          this.subscribeToOverlayRef();
+        }
+      });
+  }
+
+  ngOnInit() {
+    this.createOverlay();
+  }
+
+  ngOnDestroy() {
+    this.unlistenAll();
+    this.overlayRefSubscription?.unsubscribe();
+    this.overlayRef?.dispose();
+  }
+
+  show() {
+    if (this.isVisible()) {
+      return;
+    }
+
+    if (!this.overlayRef) {
+      this.createOverlay();
+    }
+
+    const templatePortal = new TemplatePortal(this.zContent(), this.viewContainerRef);
+    this.overlayRef?.attach(templatePortal);
+    this.isVisible.set(true);
+    this.zVisibleChange.emit(true);
+  }
+
+  hide() {
+    if (!this.isVisible()) {
+      return;
+    }
+
+    this.overlayRef?.detach();
+    this.isVisible.set(false);
+    this.zVisibleChange.emit(false);
+  }
+
+  toggle() {
+    if (this.isVisible()) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+
+  private createOverlay() {
+    if (isPlatformBrowser(this.platformId)) {
+      const positionStrategy = this.overlayPositionBuilder
+        .flexibleConnectedTo(this.nativeElement)
+        .withPositions(this.getPositions())
+        .withPush(false)
+        .withFlexibleDimensions(false)
+        .withViewportMargin(8);
+
+      this.overlayRef = this.overlay.create({
+        positionStrategy,
+        hasBackdrop: false,
+        scrollStrategy: this.overlay.scrollStrategies.reposition(),
+      });
+    }
+  }
+
+  private subscribeToOverlayRef(): void {
+    if (
+      this.zOverlayClickable() &&
+      this.zTrigger() === 'click' &&
+      isPlatformBrowser(this.platformId) &&
+      this.overlayRef
+    ) {
+      this.overlayRefSubscription = this.overlayRef
+        .outsidePointerEvents()
+        .pipe(filter(event => !this.nativeElement.contains(event.target)))
+        .subscribe(() => this.hide());
+    }
+  }
+
+  private setupTriggers() {
+    const trigger = this.zTrigger();
+    if (!trigger) {
+      return;
+    }
+
+    if (trigger === 'click') {
+      this.listeners.push(this.renderer.listen(this.nativeElement, 'click.stop', () => this.toggle()));
+    } else if (trigger === 'hover') {
+      this.listeners.push(this.renderer.listen(this.nativeElement, 'mouseenter', () => this.show()));
+
+      this.listeners.push(this.renderer.listen(this.nativeElement, 'mouseleave', () => this.hide()));
+    }
+  }
+
+  private unlistenAll(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+    this.listeners = [];
+  }
+
+  private getPositions(): ConnectedPosition[] {
+    const placement = this.zPlacement();
+    const positions: ConnectedPosition[] = [];
+
+    // Primary position
+    const primaryConfig = POPOVER_POSITIONS_MAP[placement];
+    positions.push({
+      originX: primaryConfig.originX,
+      originY: primaryConfig.originY,
+      overlayX: primaryConfig.overlayX,
+      overlayY: primaryConfig.overlayY,
+      offsetX: primaryConfig.offsetX ?? 0,
+      offsetY: primaryConfig.offsetY ?? 0,
+    });
+
+    // Fallback positions for better positioning when primary doesn't fit
+    switch (placement) {
+      case 'bottom':
+        // Try top if bottom doesn't fit
+        positions.push({
+          originX: 'center',
+          originY: 'top',
+          overlayX: 'center',
+          overlayY: 'bottom',
+          offsetX: 0,
+          offsetY: -8,
+        });
+        // If neither top nor bottom work, try right
+        positions.push({
+          originX: 'end',
+          originY: 'center',
+          overlayX: 'start',
+          overlayY: 'center',
+          offsetX: 8,
+          offsetY: 0,
+        });
+        // Finally try left
+        positions.push({
+          originX: 'start',
+          originY: 'center',
+          overlayX: 'end',
+          overlayY: 'center',
+          offsetX: -8,
+          offsetY: 0,
+        });
+        break;
+      case 'top':
+        // Try bottom if top doesn't fit
+        positions.push({
+          originX: 'center',
+          originY: 'bottom',
+          overlayX: 'center',
+          overlayY: 'top',
+          offsetX: 0,
+          offsetY: 8,
+        });
+        // If neither top nor bottom work, try right
+        positions.push({
+          originX: 'end',
+          originY: 'center',
+          overlayX: 'start',
+          overlayY: 'center',
+          offsetX: 8,
+          offsetY: 0,
+        });
+        // Finally try left
+        positions.push({
+          originX: 'start',
+          originY: 'center',
+          overlayX: 'end',
+          overlayY: 'center',
+          offsetX: -8,
+          offsetY: 0,
+        });
+        break;
+      case 'right':
+        // Try left if right doesn't fit
+        positions.push({
+          originX: 'start',
+          originY: 'center',
+          overlayX: 'end',
+          overlayY: 'center',
+          offsetX: -8,
+          offsetY: 0,
+        });
+        // If neither left nor right work, try bottom
+        positions.push({
+          originX: 'center',
+          originY: 'bottom',
+          overlayX: 'center',
+          overlayY: 'top',
+          offsetX: 0,
+          offsetY: 8,
+        });
+        // Finally try top
+        positions.push({
+          originX: 'center',
+          originY: 'top',
+          overlayX: 'center',
+          overlayY: 'bottom',
+          offsetX: 0,
+          offsetY: -8,
+        });
+        break;
+      case 'left':
+        // Try right if left doesn't fit
+        positions.push({
+          originX: 'end',
+          originY: 'center',
+          overlayX: 'start',
+          overlayY: 'center',
+          offsetX: 8,
+          offsetY: 0,
+        });
+        // If neither left nor right work, try bottom
+        positions.push({
+          originX: 'center',
+          originY: 'bottom',
+          overlayX: 'center',
+          overlayY: 'top',
+          offsetX: 0,
+          offsetY: 8,
+        });
+        // Finally try top
+        positions.push({
+          originX: 'center',
+          originY: 'top',
+          overlayX: 'center',
+          overlayY: 'bottom',
+          offsetX: 0,
+          offsetY: -8,
+        });
+        break;
+    }
+
+    return positions;
+  }
+}
+
+@Component({
+  selector: 'z-popover',
+  imports: [],
+  standalone: true,
+  template: `
+    <ng-content />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[class]': 'classes()',
+  },
+})
+export class ZardPopoverComponent {
+  readonly class = input<string>('');
+
+  protected readonly classes = computed(() => mergeClasses(popoverVariants(), this.class()));
+}

--- a/v2/ui/popover/popover.variants.ts
+++ b/v2/ui/popover/popover.variants.ts
@@ -20,16 +20,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './calendar';
-export * from './date-picker';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './loader';
-export * from './pagination';
-export * from './popover';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const popoverVariants = cva(
+  'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+);
+
+export type ZardPopoverVariants = VariantProps<typeof popoverVariants>;


### PR DESCRIPTION
## What

Adds the **datepicker** to `v2/ui` — the most complex component on the list. It needs two building blocks that didn't exist yet, so this PR includes all three (one self-contained unit):

| Piece | Files | Notes |
|---|---|---|
| **popover** | `popover/` | `z-popover` + `zPopover` directive — CDK-overlay, click/hover triggers, flexible placement with fallbacks. A reusable primitive (tooltip/menu/etc. can build on it). |
| **calendar** | `calendar/` | `z-calendar` + grid + month/year navigation; date math in `calendar.utils`; single / multiple / range modes; min/max constraints. Native `Date`, **no external date lib**. |
| **date-picker** | `date-picker/` | `z-date-picker` — a button that opens the calendar in the popover; `ControlValueAccessor` + `DatePipe` formatting (`zFormat`). |

Replaces Material's `mat-datepicker`.

Usage:
```html
<z-date-picker [(ngModel)]="date" zFormat="dd-MM-yyyy" [minDate]="min" [maxDate]="max" />
```

## Notes
- Faithful ZardUI ports — identical to source apart from relative import paths, AMRIT GPL-3.0 headers, and `z-icon` → `@ng-icons/lucide` (calendar/chevron icons).
- Reuses the shared **button** and **select** (calendar's month/year dropdowns).
- The popover's `click.stop` trigger relies on `provideZard()` (already registered app-side from the select PR).
- No new npm dependency (CDK already present).
- Independent branch off `angular-zard-migration` (only `v2/ui/index.ts` is shared with the other open PRs — auto-merges).
- Verified by building the full stack inside MMU-UI (consumed `z-date-picker`, then reverted); lint clean.

## Note for the reviewer
Popover is bundled here because date-picker depends on it. Happy to split popover into its own PR first if you'd prefer smaller units — let me know.

## Next in the priority list
checkbox → tooltip → card → …

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a calendar/date picker with month/year navigation, selectable single/multiple/range modes, and min/max date limits.
  * Added a standalone popover (floating content) with click/hover triggers and placement-based positioning.
  * Enhanced accessibility with keyboard navigation, focus management, and day-level ARIA labels.
* **Bug Fixes**
  * Improved date parsing/normalization with stricter validation to avoid invalid/rolled-over dates and reduce timezone-related issues.
* **Refactor**
  * Expanded public UI entry points with new calendar, date picker, and popover exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->