### PR TITLE
feat(ui): add card, list, menu, tooltip components

### DIFF
--- a/v2/ui/card/card.component.ts
+++ b/v2/ui/card/card.component.ts
@@ -1,0 +1,104 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+import { cardVariants } from './card.variants';
+
+@Component({
+  selector: 'z-card',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+  exportAs: 'zCard',
+})
+export class ZardCardComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses(cardVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-card-header',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+})
+export class ZardCardHeaderComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() =>
+    mergeClasses('grid auto-rows-min items-start gap-1.5 px-6', this.class()),
+  );
+}
+
+@Component({
+  selector: 'z-card-title',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+})
+export class ZardCardTitleComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses('leading-none font-semibold', this.class()));
+}
+
+@Component({
+  selector: 'z-card-description',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+})
+export class ZardCardDescriptionComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() =>
+    mergeClasses('text-muted-foreground text-sm', this.class()),
+  );
+}
+
+@Component({
+  selector: 'z-card-content',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+})
+export class ZardCardContentComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses('px-6', this.class()));
+}
+
+@Component({
+  selector: 'z-card-footer',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+})
+export class ZardCardFooterComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses('flex items-center px-6', this.class()));
+}

--- a/v2/ui/card/card.imports.ts
+++ b/v2/ui/card/card.imports.ts
@@ -20,17 +20,20 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+import {
+  ZardCardComponent,
+  ZardCardContentComponent,
+  ZardCardDescriptionComponent,
+  ZardCardFooterComponent,
+  ZardCardHeaderComponent,
+  ZardCardTitleComponent,
+} from './card.component';
+
+export const cardImports = [
+  ZardCardComponent,
+  ZardCardHeaderComponent,
+  ZardCardTitleComponent,
+  ZardCardDescriptionComponent,
+  ZardCardContentComponent,
+  ZardCardFooterComponent,
+] as const;

--- a/v2/ui/card/card.variants.ts
+++ b/v2/ui/card/card.variants.ts
@@ -20,17 +20,9 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const cardVariants = cva(
+  'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+);
+export type ZardCardVariants = VariantProps<typeof cardVariants>;

--- a/v2/ui/card/index.ts
+++ b/v2/ui/card/index.ts
@@ -20,17 +20,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+export * from './card.component';
+export * from './card.variants';
+export * from './card.imports';

--- a/v2/ui/list/index.ts
+++ b/v2/ui/list/index.ts
@@ -20,17 +20,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+export * from './list.component';
+export * from './list.variants';
+export * from './list.imports';

--- a/v2/ui/list/list.component.ts
+++ b/v2/ui/list/list.component.ts
@@ -1,0 +1,53 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+import { listItemVariants, listVariants } from './list.variants';
+
+@Component({
+  selector: 'z-list, ul[z-list]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()', role: 'list' },
+  exportAs: 'zList',
+})
+export class ZardListComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses(listVariants(), this.class()));
+}
+
+@Component({
+  selector: 'z-list-item, li[z-list-item]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()', role: 'listitem' },
+  exportAs: 'zListItem',
+})
+export class ZardListItemComponent {
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses(listItemVariants(), this.class()));
+}

--- a/v2/ui/list/list.imports.ts
+++ b/v2/ui/list/list.imports.ts
@@ -20,17 +20,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+import { ZardListComponent, ZardListItemComponent } from './list.component';
+
+export const listImports = [ZardListComponent, ZardListItemComponent] as const;

--- a/v2/ui/list/list.variants.ts
+++ b/v2/ui/list/list.variants.ts
@@ -20,17 +20,10 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const listVariants = cva('flex w-full flex-col');
+export const listItemVariants = cva(
+  'flex items-center gap-3 rounded-md px-3 py-2 text-sm text-foreground',
+);
+export type ZardListVariants = VariantProps<typeof listVariants>;

--- a/v2/ui/menu/index.ts
+++ b/v2/ui/menu/index.ts
@@ -20,17 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+export * from './menu.component';
+export * from './menu-trigger.directive';
+export * from './menu.variants';
+export * from './menu.imports';

--- a/v2/ui/menu/menu-trigger.directive.ts
+++ b/v2/ui/menu/menu-trigger.directive.ts
@@ -1,0 +1,99 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { Overlay, OverlayPositionBuilder, type OverlayRef } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
+import {
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  type OnDestroy,
+  signal,
+  ViewContainerRef,
+} from '@angular/core';
+import { ZardMenuComponent } from './menu.component';
+
+@Directive({
+  selector: '[zMenuTriggerFor]',
+  exportAs: 'zMenuTrigger',
+  host: { '(click)': 'toggle()', '[attr.aria-expanded]': 'isOpen()' },
+})
+export class ZardMenuTriggerForDirective implements OnDestroy {
+  private readonly overlay = inject(Overlay);
+  private readonly positionBuilder = inject(OverlayPositionBuilder);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly viewContainerRef = inject(ViewContainerRef);
+
+  private overlayRef?: OverlayRef;
+  private closeSub?: { unsubscribe(): void };
+  protected readonly isOpen = signal(false);
+
+  readonly menu = input.required<ZardMenuComponent>({ alias: 'zMenuTriggerFor' });
+
+  toggle(): void {
+    this.isOpen() ? this.close() : this.open();
+  }
+
+  open(): void {
+    if (this.isOpen()) {
+      return;
+    }
+    if (!this.overlayRef) {
+      this.createOverlay();
+    }
+    this.overlayRef!.attach(new TemplatePortal(this.menu().templateRef(), this.viewContainerRef));
+    this.isOpen.set(true);
+  }
+
+  close(): void {
+    if (!this.isOpen()) {
+      return;
+    }
+    this.overlayRef?.detach();
+    this.isOpen.set(false);
+  }
+
+  private createOverlay(): void {
+    const positionStrategy = this.positionBuilder.flexibleConnectedTo(this.elementRef).withPositions([
+      { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top', offsetY: 4 },
+      { originX: 'start', originY: 'top', overlayX: 'start', overlayY: 'bottom', offsetY: -4 },
+    ]);
+    this.overlayRef = this.overlay.create({
+      positionStrategy,
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+    });
+    // Close on outside click (ignore clicks on the trigger itself — its own handler toggles).
+    this.overlayRef.outsidePointerEvents().subscribe((event) => {
+      if (!this.elementRef.nativeElement.contains(event.target as Node)) {
+        this.close();
+      }
+    });
+    // Close when a menu item requests it.
+    this.closeSub = this.menu().closed.subscribe(() => this.close());
+  }
+
+  ngOnDestroy(): void {
+    this.closeSub?.unsubscribe();
+    this.overlayRef?.dispose();
+  }
+}

--- a/v2/ui/menu/menu-trigger.directive.ts
+++ b/v2/ui/menu/menu-trigger.directive.ts
@@ -89,7 +89,7 @@ export class ZardMenuTriggerForDirective implements OnDestroy {
     }
   }
 
-  private onMenuKeydown = (event: KeyboardEvent): void => {
+  private readonly onMenuKeydown = (event: KeyboardEvent): void => {
     if (!this.isOpen()) {
       return;
     }

--- a/v2/ui/menu/menu-trigger.directive.ts
+++ b/v2/ui/menu/menu-trigger.directive.ts
@@ -36,7 +36,12 @@ import { ZardMenuComponent } from './menu.component';
 @Directive({
   selector: '[zMenuTriggerFor]',
   exportAs: 'zMenuTrigger',
-  host: { '(click)': 'toggle()', '[attr.aria-expanded]': 'isOpen()' },
+  host: {
+    '(click)': 'toggle()',
+    '(keydown)': 'onTriggerKeydown($event)',
+    '[attr.aria-expanded]': 'isOpen()',
+    '[attr.aria-haspopup]': '"menu"',
+  },
 })
 export class ZardMenuTriggerForDirective implements OnDestroy {
   private readonly overlay = inject(Overlay);
@@ -63,6 +68,8 @@ export class ZardMenuTriggerForDirective implements OnDestroy {
     }
     this.overlayRef!.attach(new TemplatePortal(this.menu().templateRef(), this.viewContainerRef));
     this.isOpen.set(true);
+    // Move focus into the menu (parity with Material md-menu).
+    queueMicrotask(() => this.focusItem(0));
   }
 
   close(): void {
@@ -71,6 +78,66 @@ export class ZardMenuTriggerForDirective implements OnDestroy {
     }
     this.overlayRef?.detach();
     this.isOpen.set(false);
+    // Restore focus to the trigger.
+    this.elementRef.nativeElement.focus();
+  }
+
+  onTriggerKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowDown' && !this.isOpen()) {
+      event.preventDefault();
+      this.open();
+    }
+  }
+
+  private onMenuKeydown = (event: KeyboardEvent): void => {
+    if (!this.isOpen()) {
+      return;
+    }
+    const items = this.getItems();
+    const current = items.indexOf(document.activeElement as HTMLElement);
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.focusItem(current + 1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.focusItem(current - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        this.focusItem(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        this.focusItem(items.length - 1);
+        break;
+      case 'Escape':
+        event.preventDefault();
+        this.close();
+        break;
+      case 'Tab':
+        this.close();
+        break;
+    }
+  };
+
+  private getItems(): HTMLElement[] {
+    if (!this.overlayRef) {
+      return [];
+    }
+    return Array.from(
+      this.overlayRef.overlayElement.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).filter((el) => el.getAttribute('aria-disabled') !== 'true');
+  }
+
+  private focusItem(index: number): void {
+    const items = this.getItems();
+    if (!items.length) {
+      return;
+    }
+    const i = ((index % items.length) + items.length) % items.length;
+    items[i].focus();
   }
 
   private createOverlay(): void {
@@ -82,6 +149,7 @@ export class ZardMenuTriggerForDirective implements OnDestroy {
       positionStrategy,
       scrollStrategy: this.overlay.scrollStrategies.reposition(),
     });
+    this.overlayRef.overlayElement.addEventListener('keydown', this.onMenuKeydown);
     // Close on outside click (ignore clicks on the trigger itself — its own handler toggles).
     this.overlayRef.outsidePointerEvents().subscribe((event) => {
       if (!this.elementRef.nativeElement.contains(event.target as Node)) {

--- a/v2/ui/menu/menu.component.ts
+++ b/v2/ui/menu/menu.component.ts
@@ -21,6 +21,7 @@
  */
 
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
   computed,
@@ -63,15 +64,29 @@ export class ZardMenuComponent {
   template: '<ng-content />',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  host: { '[class]': 'classes()', role: 'menuitem', '(click)': 'onClick()' },
+  host: {
+    '[class]': 'classes()',
+    role: 'menuitem',
+    // Roving tabindex: items are programmatically focusable (arrow-key nav), not in tab order.
+    '[attr.tabindex]': 'zDisabled() ? null : -1',
+    '[attr.aria-disabled]': 'zDisabled() || null',
+    '[attr.disabled]': 'zDisabled() ? "" : null',
+    '(click)': 'onClick($event)',
+  },
   exportAs: 'zMenuItem',
 })
 export class ZardMenuItemComponent {
   private readonly menu = inject(ZardMenuComponent, { optional: true });
   readonly class = input<ClassValue>('');
+  readonly zDisabled = input(false, { transform: booleanAttribute });
   protected readonly classes = computed(() => mergeClasses(menuItemVariants(), this.class()));
 
-  onClick(): void {
+  onClick(event: Event): void {
+    if (this.zDisabled()) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
     this.menu?.requestClose();
   }
 }

--- a/v2/ui/menu/menu.component.ts
+++ b/v2/ui/menu/menu.component.ts
@@ -1,0 +1,77 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  type TemplateRef,
+  ViewEncapsulation,
+  viewChild,
+} from '@angular/core';
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+import { menuItemVariants, menuVariants } from './menu.variants';
+
+@Component({
+  selector: 'z-menu',
+  template: `
+    <ng-template #zMenuTemplate>
+      <div [class]="classes()" role="menu"><ng-content /></div>
+    </ng-template>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zMenu',
+})
+export class ZardMenuComponent {
+  readonly class = input<ClassValue>('');
+  readonly closed = output<void>();
+  readonly templateRef = viewChild.required<TemplateRef<unknown>>('zMenuTemplate');
+  protected readonly classes = computed(() => mergeClasses(menuVariants(), this.class()));
+
+  requestClose(): void {
+    this.closed.emit();
+  }
+}
+
+@Component({
+  selector: 'z-menu-item, button[z-menu-item]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()', role: 'menuitem', '(click)': 'onClick()' },
+  exportAs: 'zMenuItem',
+})
+export class ZardMenuItemComponent {
+  private readonly menu = inject(ZardMenuComponent, { optional: true });
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses(menuItemVariants(), this.class()));
+
+  onClick(): void {
+    this.menu?.requestClose();
+  }
+}

--- a/v2/ui/menu/menu.imports.ts
+++ b/v2/ui/menu/menu.imports.ts
@@ -20,17 +20,11 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+import { ZardMenuComponent, ZardMenuItemComponent } from './menu.component';
+import { ZardMenuTriggerForDirective } from './menu-trigger.directive';
+
+export const menuImports = [
+  ZardMenuComponent,
+  ZardMenuItemComponent,
+  ZardMenuTriggerForDirective,
+] as const;

--- a/v2/ui/menu/menu.variants.ts
+++ b/v2/ui/menu/menu.variants.ts
@@ -20,17 +20,12 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const menuVariants = cva(
+  'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+);
+export const menuItemVariants = cva(
+  'relative flex w-full cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50',
+);
+export type ZardMenuVariants = VariantProps<typeof menuVariants>;

--- a/v2/ui/tooltip/index.ts
+++ b/v2/ui/tooltip/index.ts
@@ -20,17 +20,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+export * from './tooltip.component';
+export * from './tooltip.variants';
+export * from './tooltip.imports';

--- a/v2/ui/tooltip/tooltip.component.ts
+++ b/v2/ui/tooltip/tooltip.component.ts
@@ -48,10 +48,11 @@ import { tooltipVariants, type ZardTooltipPosition } from './tooltip.variants';
   template: `{{ text() }}`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  host: { '[class]': 'classes()', role: 'tooltip' },
+  host: { '[class]': 'classes()', '[id]': 'id()', role: 'tooltip' },
 })
 export class ZardTooltipComponent {
   readonly text = input<string>('');
+  readonly id = input<string>('');
   readonly class = input<ClassValue>('');
   protected readonly classes = computed(() => mergeClasses(tooltipVariants(), this.class()));
 }
@@ -62,6 +63,8 @@ const POSITIONS: Record<ZardTooltipPosition, ConnectedPosition[]> = {
   left: [{ originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -8 }],
   right: [{ originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: 8 }],
 };
+
+let uniqueId = 0;
 
 @Directive({
   selector: '[zTooltip]',
@@ -78,24 +81,40 @@ export class ZardTooltipDirective implements OnDestroy {
   private readonly positionBuilder = inject(OverlayPositionBuilder);
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   private overlayRef?: OverlayRef;
+  private showTimer?: ReturnType<typeof setTimeout>;
+  private readonly tooltipId = `z-tooltip-${uniqueId++}`;
 
   readonly zTooltip = input<string>('');
   readonly zPosition = input<ZardTooltipPosition>('top');
+  /** Delay (ms) before the tooltip appears on hover/focus. */
+  readonly zDelay = input<number>(0);
 
   show(): void {
-    const text = this.zTooltip();
-    if (!text || this.overlayRef?.hasAttached()) {
+    if (!this.zTooltip() || this.overlayRef?.hasAttached()) {
       return;
     }
-    if (!this.overlayRef) {
-      this.createOverlay();
-    }
-    const ref = this.overlayRef!.attach(new ComponentPortal(ZardTooltipComponent));
-    ref.setInput('text', text);
+    clearTimeout(this.showTimer);
+    this.showTimer = setTimeout(() => this.attach(), this.zDelay());
   }
 
   hide(): void {
+    clearTimeout(this.showTimer);
     this.overlayRef?.detach();
+    this.elementRef.nativeElement.removeAttribute('aria-describedby');
+  }
+
+  private attach(): void {
+    if (!this.overlayRef) {
+      this.createOverlay();
+    }
+    if (this.overlayRef!.hasAttached()) {
+      return;
+    }
+    const ref = this.overlayRef!.attach(new ComponentPortal(ZardTooltipComponent));
+    ref.setInput('text', this.zTooltip());
+    ref.setInput('id', this.tooltipId);
+    // Associate the trigger with the tooltip for screen readers (parity with mdTooltip).
+    this.elementRef.nativeElement.setAttribute('aria-describedby', this.tooltipId);
   }
 
   private createOverlay(): void {
@@ -109,6 +128,8 @@ export class ZardTooltipDirective implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    clearTimeout(this.showTimer);
+    this.elementRef.nativeElement.removeAttribute('aria-describedby');
     this.overlayRef?.dispose();
   }
 }

--- a/v2/ui/tooltip/tooltip.component.ts
+++ b/v2/ui/tooltip/tooltip.component.ts
@@ -1,0 +1,114 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  type ConnectedPosition,
+  Overlay,
+  OverlayPositionBuilder,
+  type OverlayRef,
+} from '@angular/cdk/overlay';
+import { ComponentPortal } from '@angular/cdk/portal';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  type OnDestroy,
+  ViewEncapsulation,
+} from '@angular/core';
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+import { tooltipVariants, type ZardTooltipPosition } from './tooltip.variants';
+
+@Component({
+  selector: 'z-tooltip',
+  template: `{{ text() }}`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()', role: 'tooltip' },
+})
+export class ZardTooltipComponent {
+  readonly text = input<string>('');
+  readonly class = input<ClassValue>('');
+  protected readonly classes = computed(() => mergeClasses(tooltipVariants(), this.class()));
+}
+
+const POSITIONS: Record<ZardTooltipPosition, ConnectedPosition[]> = {
+  top: [{ originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom', offsetY: -8 }],
+  bottom: [{ originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top', offsetY: 8 }],
+  left: [{ originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center', offsetX: -8 }],
+  right: [{ originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center', offsetX: 8 }],
+};
+
+@Directive({
+  selector: '[zTooltip]',
+  exportAs: 'zTooltip',
+  host: {
+    '(mouseenter)': 'show()',
+    '(mouseleave)': 'hide()',
+    '(focusin)': 'show()',
+    '(focusout)': 'hide()',
+  },
+})
+export class ZardTooltipDirective implements OnDestroy {
+  private readonly overlay = inject(Overlay);
+  private readonly positionBuilder = inject(OverlayPositionBuilder);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+  private overlayRef?: OverlayRef;
+
+  readonly zTooltip = input<string>('');
+  readonly zPosition = input<ZardTooltipPosition>('top');
+
+  show(): void {
+    const text = this.zTooltip();
+    if (!text || this.overlayRef?.hasAttached()) {
+      return;
+    }
+    if (!this.overlayRef) {
+      this.createOverlay();
+    }
+    const ref = this.overlayRef!.attach(new ComponentPortal(ZardTooltipComponent));
+    ref.setInput('text', text);
+  }
+
+  hide(): void {
+    this.overlayRef?.detach();
+  }
+
+  private createOverlay(): void {
+    const positionStrategy = this.positionBuilder
+      .flexibleConnectedTo(this.elementRef)
+      .withPositions(POSITIONS[this.zPosition()]);
+    this.overlayRef = this.overlay.create({
+      positionStrategy,
+      scrollStrategy: this.overlay.scrollStrategies.reposition(),
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.overlayRef?.dispose();
+  }
+}

--- a/v2/ui/tooltip/tooltip.imports.ts
+++ b/v2/ui/tooltip/tooltip.imports.ts
@@ -20,17 +20,6 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+import { ZardTooltipDirective } from './tooltip.component';
+
+export const tooltipImports = [ZardTooltipDirective] as const;

--- a/v2/ui/tooltip/tooltip.variants.ts
+++ b/v2/ui/tooltip/tooltip.variants.ts
@@ -20,17 +20,11 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-export * from './button';
-export * from './card';
-export * from './dialog';
-export * from './form';
-export * from './input';
-export * from './list';
-export * from './loader';
-export * from './menu';
-export * from './pagination';
-export * from './provider';
-export * from './select';
-export * from './table';
-export * from './toast';
-export * from './tooltip';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const tooltipVariants = cva(
+  'z-50 w-fit max-w-xs rounded-md bg-primary px-3 py-1.5 text-xs text-balance text-primary-foreground shadow-md',
+);
+export type ZardTooltipVariants = VariantProps<typeof tooltipVariants>;
+
+export type ZardTooltipPosition = 'top' | 'right' | 'bottom' | 'left';


### PR DESCRIPTION
## 📋 Description

Adds four shared ZardUI primitives to v2/ui for the AMRIT front-ends:

- card - z-card + header/title/description/content/footer
- list - z-list + z-list-item
- tooltip - [zTooltip] / [zPosition] directive (hover & focus, CDK overlay)
- menu - [zMenuTriggerFor] + <z-menu> + z-menu-item (Material-style API; closes on item click & outside click)

Follow the existing kit conventions (cva *.variants.ts, signal class input + mergeClasses, *.imports.ts, index.ts, GPL header) and are exported from the v2/ui barrel. Compile- and runtime-verified against a host Angular 20 app (zoneless).

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [x] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

