### PR TITLE
fix(form): bound z-form-field column so wide controls truncate

### DIFF
--- a/v2/ui/form/form.variants.ts
+++ b/v2/ui/form/form.variants.ts
@@ -22,7 +22,10 @@
 
 import { cva, type VariantProps } from 'class-variance-authority';
 
-export const formFieldVariants = cva('grid gap-2');
+// grid-cols-1 = minmax(0, 1fr): the field's single column fills its width
+// instead of growing to a control's max-content (e.g. a long z-select label),
+// so wide selects/inputs stay bounded and truncate instead of overflowing.
+export const formFieldVariants = cva('grid grid-cols-1 gap-2');
 
 export const formLabelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',


### PR DESCRIPTION
## What

`z-form-field` used a bare `grid`, whose implicit `auto` column grows to a control's **max-content**. A long `z-select` label (e.g. a security question) therefore overflowed the field and stretched the surrounding card.

This switches the field to `grid grid-cols-1` (`minmax(0, 1fr)`) so the single column **fills the field width** and wide selects/inputs **truncate** instead of overflowing.

## Why

Every select-in-form screen across the apps hits this (security questions, service-point, worklist filters, …). Fixing it once in the shared form primitive avoids per-usage workarounds.

## Impact

- One-line change in `formFieldVariants`.
- Existing single-column fields render identically — the only behavioural change is that an over-wide control is now bounded.

## Before / After

- **Before:** selecting a long option pushed the `z-select` (and the card) past its width.
- **After:** the trigger stays within the field and the label truncates with an ellipsis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field layout so inputs stay in a single-column grid.
  * Prevented long content from overflowing and disrupting form display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->