### PR TITLE
fix(button): let z-button size its own ng-icon (drop per-icon size=)

### DIFF
--- a/v2/ui/button/button.variants.ts
+++ b/v2/ui/button/button.variants.ts
@@ -30,7 +30,7 @@ export const buttonVariants = cva(
     'aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding',
     "text-sm font-medium focus-visible:ring-3 aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 inline-flex items-center",
     'justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none',
-    'shrink-0 [&_svg]:shrink-0 outline-none group/button select-none [&_ng-icon]:flex [&_ng-icon]:items-center',
+    "shrink-0 [&_svg]:shrink-0 outline-none group/button select-none [&_ng-icon]:flex [&_ng-icon]:items-center [&_ng-icon:not([size])]:[--ng-icon__size:1rem]",
   ),
   {
     variants: {
@@ -48,14 +48,15 @@ export const buttonVariants = cva(
       },
       zSize: {
         default: 'h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
-        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
-        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3 [&_ng-icon:not([size])]:[--ng-icon__size:0.75rem]",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5 [&_ng-icon:not([size])]:[--ng-icon__size:0.875rem]",
         lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3',
         icon: 'size-8',
         'icon-xs':
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3 [&_ng-icon:not([size])]:[--ng-icon__size:0.75rem]",
         'icon-sm': 'size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg',
-        'icon-lg': 'size-9',
+        'icon-lg':
+          "size-9 [&_svg:not([class*='size-'])]:size-5 [&_ng-icon:not([size])]:[--ng-icon__size:1.25rem]",
       },
       zShape: {
         default: 'rounded-md',


### PR DESCRIPTION
## What
`z-button` now sizes the `@ng-icons` icons it contains, so callers no longer need to repeat a `size=` attribute on every icon.

## Why
The button sized icons with `[&_svg]:size-*` — the shadcn/lucide-react pattern, which assumes the icon is a **plain `<svg>`**. We don't use plain svgs; we use **`@ng-icons`**, whose `<ng-icon>`:

- renders the svg with `width: inherit; height: inherit` (the svg copies its host), and
- sizes the host from `--ng-icon__size` (default `1em`) in an **unlayered `:host` rule**.

Because that `:host` rule is **unlayered**, it beats the button's **layered** `[&_svg]:size-*` utility. So the button could never actually control an `@ng-icons` icon's size — the icon fell back to the button's font-size (~14px). Every caller worked around it by hand-setting `size="16"` / `size="20"` on each icon, which CodeRabbit (rightly, for shadcn-React) flags as an anti-pattern.

## How
Set `--ng-icon__size` on the button **per size variant** instead of trying to size the svg directly. `--ng-icon__size` is an **inherited custom property** that the icon's own `width: var(--ng-icon__size, 1em)` rule reads — so there's **no layer/specificity conflict**, and the button now genuinely controls icon size.

| Variant | `--ng-icon__size` |
|---|---|
| base (default / lg / icon / icon-sm) | 1rem (16px) |
| xs / icon-xs | 0.75rem (12px) |
| sm | 0.875rem (14px) |
| icon-lg | 1.25rem (20px) — `svg` rule bumped to `size-5` to match |

- Sizes mirror the existing `[&_svg]:size-*` scale, so plain-`svg` callers are unchanged.
- `:not([size])` guard means an explicit `size=` on an `<ng-icon>` still overrides the button (escape hatch preserved).

## Impact
Backwards compatible. Consuming apps can now drop `size=` from icons that sit inside a `z-button` (icon scales with the button's size variant); icons outside a button and explicit `size=` overrides are unaffected. Independent of Material/Bootstrap — this is purely a Zard + `@ng-icons` interaction.