### PR TITLE
fix(input): add shadcn shadow-xs to z-input (default + textarea)

### DIFF
--- a/v2/ui/input/input.variants.ts
+++ b/v2/ui/input/input.variants.ts
@@ -28,9 +28,9 @@ export const inputVariants = cva('w-full min-w-0', {
   variants: {
     zType: {
       default:
-        'flex rounded-lg border border-input bg-transparent px-2.5 font-normal transition-colors file:inline-flex file:border-0 file:bg-transparent file:font-medium file:text-foreground placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30 dark:disabled:bg-input/80',
+        'flex rounded-lg border border-input bg-transparent px-2.5 font-normal shadow-xs transition-colors file:inline-flex file:border-0 file:bg-transparent file:font-medium file:text-foreground placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30 dark:disabled:bg-input/80',
       textarea:
-        'flex pb-2 min-h-20 h-auto rounded-lg border border-input bg-transparent px-3 py-2 text-base transition-colors placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30 dark:disabled:bg-input/80',
+        'flex pb-2 min-h-20 h-auto rounded-lg border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-colors placeholder:text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30 dark:disabled:bg-input/80',
     },
     zSize: {
       default: 'text-base md:text-sm',


### PR DESCRIPTION
## What
Adds shadcn's subtle `shadow-xs` to the `z-input` `default` and `textarea` variants.

## Why
shadcn's `Input` component carries a `shadow-xs`. Combined with a white surface and the 1px `border-input`, that soft shadow — **not** a dark border — is what makes a field read clearly. Our `z-input` omitted it, so on non-white surfaces (e.g. a worklist toolbar over the app's gray canvas) the field looked faint/see-through, and screens compensated with ad-hoc per-field classes.

Per the real shadcn theme, `--input` equals `--border` (a subtle light gray, `oklch(0.922 0 0)`); the border is intentionally **not** darkened. The correct shadcn way to make a field legible is white fill + `shadow-xs`.

## How
`shadow-xs` added to both `default` and `textarea` zType variants. Borderless/ghost inputs are untouched.

## Impact
Backwards compatible and purely visual. Every `z-input` now matches shadcn's field affordance out of the box, so consumers no longer need per-field shadow workarounds. No API change.