### PR TITLE
style(tabs): highlight the active z-tab with a primary fill

### DIFF
--- a/v2/ui/tabs/tabs.variants.ts
+++ b/v2/ui/tabs/tabs.variants.ts
@@ -67,8 +67,10 @@ export const tabButtonVariants = cva('hover:bg-transparent rounded-none shrink-0
       right: '',
     },
     isActive: {
-      true: '',
-      false: '',
+      // The active tab keeps its fill on hover (override the ghost
+      // button's built-in hover:bg-muted so it doesn't read as inactive).
+      true: 'bg-primary/10 text-foreground hover:bg-primary/10!',
+      false: 'text-muted-foreground',
     },
   },
   compoundVariants: [


### PR DESCRIPTION
## What

Give the active `z-tab-group` tab a clear, on-theme selected state:

- **Active tab** → subtle primary-tinted fill (`bg-primary/10`) + `text-foreground`, on top of the existing primary active border.
- **Inactive tab** → `text-muted-foreground`.
- The active fill is preserved on hover (`hover:bg-primary/10!`) so hovering the selected tab no longer overrides it with the ghost button's built-in `hover:bg-muted`, which made the active tab momentarily read as inactive.

## Why

The stock z-tab active state was only a faint bottom border inside an otherwise identical-looking box, so users couldn't tell which tab was selected. This makes the active/inactive distinction obvious while staying within the shadcn token system (no hardcoded colors).

## Scope

`tabButtonVariants` only — affects every `z-tab-group`. Today the sole consumer across the AMRIT apps is the MMU nurse worklist tabs (Visit / Referred to TC); Helpline104/1097 don't render tabs yet, so they're unaffected.