### PR TITLE
feat(v2/ui): add the Zard primitives MMU's screen migration needs (radio-group, accordion, combobox, toggle-group, badge, stepper, sheet)

### DIFF
--- a/v2/ui/accordion/accordion.component.ts
+++ b/v2/ui/accordion/accordion.component.ts
@@ -169,7 +169,10 @@ export class ZardAccordionTriggerComponent {
 @Component({
   selector: 'z-accordion-content, [z-accordion-content]',
   template: `
-    <div class="overflow-hidden">
+    <div
+      class="overflow-hidden"
+      [attr.inert]="open() ? null : ''"
+      [attr.aria-hidden]="open() ? null : 'true'">
       <div class="pb-4 pt-0">
         <ng-content />
       </div>

--- a/v2/ui/accordion/accordion.component.ts
+++ b/v2/ui/accordion/accordion.component.ts
@@ -1,0 +1,200 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+  ViewEncapsulation,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideChevronDown } from '@ng-icons/lucide';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+import {
+  accordionChevronVariants,
+  accordionContentVariants,
+  accordionItemVariants,
+  accordionTriggerVariants,
+  accordionVariants,
+} from './accordion.variants';
+
+export type ZardAccordionType = 'single' | 'multiple';
+
+@Component({
+  selector: 'z-accordion, [z-accordion]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+  exportAs: 'zAccordion',
+})
+export class ZardAccordionComponent {
+  readonly class = input<ClassValue>('');
+  readonly zType = input<ZardAccordionType>('single');
+  readonly zCollapsible = input(true, { transform: booleanAttribute });
+
+  /** Emits the full set of currently open item values whenever it changes. */
+  readonly zValueChange = output<string[]>();
+
+  // Source of truth for which items are open.
+  private readonly openValues = signal<Set<string>>(new Set());
+
+  protected readonly classes = computed(() =>
+    mergeClasses(accordionVariants(), this.class())
+  );
+
+  isOpen(value: string): boolean {
+    return this.openValues().has(value);
+  }
+
+  toggle(value: string): void {
+    const current = this.openValues();
+    const next = new Set(current);
+
+    if (next.has(value)) {
+      // Closing the open item — only allowed when collapsible (single mode)
+      // or always allowed in multiple mode.
+      if (this.zType() === 'single' && !this.zCollapsible()) {
+        return;
+      }
+      next.delete(value);
+    } else if (this.zType() === 'single') {
+      // Opening in single mode closes every other item.
+      next.clear();
+      next.add(value);
+    } else {
+      next.add(value);
+    }
+
+    this.openValues.set(next);
+    this.zValueChange.emit([...next]);
+  }
+}
+
+@Component({
+  selector: 'z-accordion-item, [z-accordion-item]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+    '[attr.data-state]': "open() ? 'open' : 'closed'",
+  },
+  exportAs: 'zAccordionItem',
+})
+export class ZardAccordionItemComponent {
+  private readonly accordion = inject(ZardAccordionComponent);
+
+  readonly class = input<ClassValue>('');
+  readonly zValue = input.required<string>();
+
+  readonly open = computed(() => this.accordion.isOpen(this.zValue()));
+
+  protected readonly classes = computed(() =>
+    mergeClasses(accordionItemVariants(), this.class())
+  );
+
+  toggle(): void {
+    this.accordion.toggle(this.zValue());
+  }
+}
+
+@Component({
+  selector: 'z-accordion-trigger, [z-accordion-trigger]',
+  imports: [NgIcon],
+  viewProviders: [provideIcons({ lucideChevronDown })],
+  template: `
+    <button
+      type="button"
+      [class]="classes()"
+      [attr.aria-expanded]="open()"
+      [attr.data-state]="open() ? 'open' : 'closed'"
+      (click)="onClick()">
+      <ng-content />
+      <ng-icon name="lucideChevronDown" [class]="chevronClasses()" />
+    </button>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zAccordionTrigger',
+})
+export class ZardAccordionTriggerComponent {
+  private readonly item = inject(ZardAccordionItemComponent, {
+    optional: true,
+  });
+
+  readonly class = input<ClassValue>('');
+
+  readonly open = computed(() => this.item?.open() ?? false);
+
+  protected readonly classes = computed(() =>
+    mergeClasses(accordionTriggerVariants(), this.class())
+  );
+  protected readonly chevronClasses = computed(() =>
+    accordionChevronVariants({ open: this.open() })
+  );
+
+  onClick(): void {
+    this.item?.toggle();
+  }
+}
+
+@Component({
+  selector: 'z-accordion-content, [z-accordion-content]',
+  template: `
+    <div class="overflow-hidden">
+      <div class="pb-4 pt-0">
+        <ng-content />
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    '[class]': 'classes()',
+    '[style.gridTemplateRows]': "open() ? '1fr' : '0fr'",
+    '[attr.data-state]': "open() ? 'open' : 'closed'",
+    role: 'region',
+  },
+  exportAs: 'zAccordionContent',
+})
+export class ZardAccordionContentComponent {
+  private readonly item = inject(ZardAccordionItemComponent, {
+    optional: true,
+  });
+
+  readonly class = input<ClassValue>('');
+
+  readonly open = computed(() => this.item?.open() ?? false);
+
+  protected readonly classes = computed(() =>
+    mergeClasses(accordionContentVariants(), this.class())
+  );
+}

--- a/v2/ui/accordion/accordion.imports.ts
+++ b/v2/ui/accordion/accordion.imports.ts
@@ -1,0 +1,35 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ZardAccordionComponent,
+  ZardAccordionContentComponent,
+  ZardAccordionItemComponent,
+  ZardAccordionTriggerComponent,
+} from './accordion.component';
+
+export const ZardAccordionImports = [
+  ZardAccordionComponent,
+  ZardAccordionItemComponent,
+  ZardAccordionTriggerComponent,
+  ZardAccordionContentComponent,
+] as const;

--- a/v2/ui/accordion/accordion.variants.ts
+++ b/v2/ui/accordion/accordion.variants.ts
@@ -1,0 +1,57 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const accordionVariants = cva('block');
+
+export const accordionItemVariants = cva('border-b');
+
+export const accordionTriggerVariants = cva(
+  'flex flex-1 w-full items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50'
+);
+
+export const accordionChevronVariants = cva(
+  'size-4 shrink-0 text-muted-foreground transition-transform duration-200',
+  {
+    variants: {
+      open: {
+        true: 'rotate-180',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      open: false,
+    },
+  }
+);
+
+export const accordionContentVariants = cva(
+  'grid text-sm transition-all duration-200'
+);
+
+export type ZardAccordionTriggerVariants = VariantProps<
+  typeof accordionTriggerVariants
+>;
+export type ZardAccordionChevronVariants = VariantProps<
+  typeof accordionChevronVariants
+>;

--- a/v2/ui/accordion/index.ts
+++ b/v2/ui/accordion/index.ts
@@ -1,0 +1,25 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './accordion.component';
+export * from './accordion.variants';
+export * from './accordion.imports';

--- a/v2/ui/badge/badge.component.ts
+++ b/v2/ui/badge/badge.component.ts
@@ -1,0 +1,54 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import { badgeVariants, type ZardBadgeVariants } from './badge.variants';
+
+@Component({
+  selector: 'z-badge, [z-badge]',
+  template: '<ng-content />',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zBadge',
+  host: {
+    '[class]': 'classes()',
+  },
+})
+export class ZardBadgeComponent {
+  readonly class = input<ClassValue>('');
+  readonly zType = input<ZardBadgeVariants['zType']>('default');
+
+  protected readonly classes = computed(() =>
+    mergeClasses(badgeVariants({ zType: this.zType() }), this.class())
+  );
+}

--- a/v2/ui/badge/badge.variants.ts
+++ b/v2/ui/badge/badge.variants.ts
@@ -1,0 +1,45 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+  {
+    variants: {
+      zType: {
+        default: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground',
+        outline: 'text-foreground',
+        success: 'border-transparent bg-success text-success-foreground',
+        warning: 'border-transparent bg-warning text-warning-foreground',
+      },
+    },
+    defaultVariants: {
+      zType: 'default',
+    },
+  }
+);
+
+export type ZardBadgeVariants = VariantProps<typeof badgeVariants>;

--- a/v2/ui/badge/index.ts
+++ b/v2/ui/badge/index.ts
@@ -1,0 +1,24 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './badge.component';
+export * from './badge.variants';

--- a/v2/ui/combobox/combobox.component.ts
+++ b/v2/ui/combobox/combobox.component.ts
@@ -222,7 +222,14 @@ export class ZardComboboxComponent implements ControlValueAccessor {
     if (typeof option === 'string') {
       return option;
     }
-    return String(option[this.zLabelKey()] ?? '');
+    const raw = option[this.zLabelKey()];
+    if (typeof raw === 'string') {
+      return raw;
+    }
+    if (typeof raw === 'number') {
+      return String(raw);
+    }
+    return '';
   }
 
   protected valueOf(option: ZardComboboxOption): unknown {
@@ -389,9 +396,13 @@ export class ZardComboboxComponent implements ControlValueAccessor {
     this.isOpen.set(true);
     const options = this.filtered();
     const selectedIndex = options.findIndex(option => this.isSelected(option));
-    this.highlightedIndex.set(
-      selectedIndex >= 0 ? selectedIndex : options.length ? 0 : -1
-    );
+    let highlight = -1;
+    if (selectedIndex >= 0) {
+      highlight = selectedIndex;
+    } else if (options.length) {
+      highlight = 0;
+    }
+    this.highlightedIndex.set(highlight);
     this.cdr.markForCheck();
   }
 

--- a/v2/ui/combobox/combobox.component.ts
+++ b/v2/ui/combobox/combobox.component.ts
@@ -1,0 +1,383 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  computed,
+  ElementRef,
+  forwardRef,
+  inject,
+  input,
+  signal,
+  ViewEncapsulation,
+} from '@angular/core';
+import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCheck, lucideSearch } from '@ng-icons/lucide';
+
+import type { ClassValue } from 'clsx';
+
+import { ZardInputDirective } from '../input';
+import { mergeClasses } from '../utils/merge-classes';
+
+import {
+  comboboxContentVariants,
+  comboboxItemIconVariants,
+  comboboxItemVariants,
+  comboboxVariants,
+} from './combobox.variants';
+
+type OnTouchedType = () => void;
+type OnChangeType = (value: unknown) => void;
+
+export type ZardComboboxOption = string | Record<string, unknown>;
+
+@Component({
+  selector: 'z-combobox, [z-combobox]',
+  imports: [NgIcon, ZardInputDirective],
+  template: `
+    <div class="relative">
+      <ng-icon
+        name="lucideSearch"
+        class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 -translate-y-1/2"
+        size="16px"
+        aria-hidden="true" />
+      <input
+        #input
+        z-input
+        type="text"
+        role="combobox"
+        autocomplete="off"
+        class="pl-9"
+        [value]="query()"
+        [disabled]="isDisabled()"
+        [placeholder]="zPlaceholder()"
+        [attr.aria-expanded]="isOpen()"
+        [attr.aria-controls]="isOpen() ? 'combobox-listbox' : null"
+        [attr.aria-activedescendant]="activeDescendantId()"
+        aria-autocomplete="list"
+        (input)="onInput($event)"
+        (focus)="onFocus()"
+        (blur)="onBlur()"
+        (keydown)="onKeydown($event)" />
+    </div>
+
+    @if (isOpen()) {
+      <div id="combobox-listbox" role="listbox" [class]="contentClasses()">
+        @for (option of filtered(); track labelOf(option); let i = $index) {
+          <div
+            role="option"
+            [id]="optionId(i)"
+            [attr.aria-selected]="isSelected(option)"
+            [class]="itemClasses(i)"
+            (mousedown)="onOptionMousedown($event, option)"
+            (mouseenter)="highlightedIndex.set(i)">
+            <span [class]="iconClasses()">
+              @if (isSelected(option)) {
+                <ng-icon name="lucideCheck" aria-hidden="true" />
+              }
+            </span>
+            <span class="min-w-0 flex-1 truncate">{{ labelOf(option) }}</span>
+          </div>
+        } @empty {
+          <div class="text-muted-foreground px-2 py-1.5 text-sm">
+            No results found.
+          </div>
+        }
+      </div>
+    }
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ZardComboboxComponent),
+      multi: true,
+    },
+  ],
+  viewProviders: [provideIcons({ lucideSearch, lucideCheck })],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zCombobox',
+  host: {
+    '[class]': 'classes()',
+    '[attr.data-disabled]': 'isDisabled() ? "" : null',
+    '[attr.data-state]': 'isOpen() ? "open" : "closed"',
+    '(document:click)': 'onDocumentClick($event)',
+  },
+})
+export class ZardComboboxComponent implements ControlValueAccessor {
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+
+  readonly class = input<ClassValue>('');
+  readonly zOptions = input<ZardComboboxOption[]>([]);
+  readonly zLabelKey = input<string>('label');
+  readonly zValueKey = input<string>('value');
+  readonly zPlaceholder = input<string>('Search...');
+  readonly disabled = input(false, { transform: booleanAttribute });
+
+  protected readonly query = signal<string>('');
+  protected readonly isOpen = signal<boolean>(false);
+  protected readonly highlightedIndex = signal<number>(-1);
+
+  // Form-driven disabled state (FormControl.disable()), combined with the input.
+  private readonly formDisabled = signal(false);
+  protected readonly isDisabled = computed(
+    () => this.disabled() || this.formDisabled()
+  );
+
+  // The currently committed form value (the option's value, not its label).
+  private readonly selectedValue = signal<unknown>(null);
+
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+  private onChange: OnChangeType = () => {};
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+  private onTouched: OnTouchedType = () => {};
+
+  protected readonly classes = computed(() =>
+    mergeClasses(comboboxVariants(), this.class())
+  );
+  protected readonly contentClasses = computed(() =>
+    mergeClasses(comboboxContentVariants())
+  );
+  protected readonly iconClasses = computed(() =>
+    mergeClasses(comboboxItemIconVariants())
+  );
+
+  // Filter options by label containing the query (case-insensitive).
+  protected readonly filtered = computed<ZardComboboxOption[]>(() => {
+    const q = this.query().trim().toLowerCase();
+    const options = this.zOptions() ?? [];
+    if (!q) {
+      return options;
+    }
+    return options.filter(option =>
+      this.labelOf(option).toLowerCase().includes(q)
+    );
+  });
+
+  protected readonly activeDescendantId = computed<string | null>(() => {
+    const index = this.highlightedIndex();
+    return this.isOpen() && index >= 0 ? this.optionId(index) : null;
+  });
+
+  protected labelOf(option: ZardComboboxOption): string {
+    if (option === null || option === undefined) {
+      return '';
+    }
+    if (typeof option === 'string') {
+      return option;
+    }
+    return String(option[this.zLabelKey()] ?? '');
+  }
+
+  protected valueOf(option: ZardComboboxOption): unknown {
+    if (typeof option === 'string') {
+      return option;
+    }
+    return option[this.zValueKey()];
+  }
+
+  protected optionId(index: number): string {
+    return `combobox-option-${index}`;
+  }
+
+  protected itemClasses(index: number): string {
+    return mergeClasses(
+      comboboxItemVariants(),
+      index === this.highlightedIndex()
+        ? 'bg-accent text-accent-foreground'
+        : ''
+    );
+  }
+
+  protected isSelected(option: ZardComboboxOption): boolean {
+    return this.valueOf(option) === this.selectedValue();
+  }
+
+  protected onInput(event: Event): void {
+    if (this.isDisabled()) {
+      return;
+    }
+    const text = (event.target as HTMLInputElement).value;
+    this.query.set(text);
+    this.open();
+    this.highlightedIndex.set(this.filtered().length ? 0 : -1);
+
+    // If the typed text exactly matches an option label, reflect it as the value.
+    const match = (this.zOptions() ?? []).find(
+      option => this.labelOf(option) === text
+    );
+    if (match) {
+      this.commit(match, false);
+    }
+  }
+
+  protected onFocus(): void {
+    if (this.isDisabled()) {
+      return;
+    }
+    this.open();
+  }
+
+  protected onBlur(): void {
+    this.onTouched();
+  }
+
+  protected onOptionMousedown(event: Event, option: ZardComboboxOption): void {
+    // mousedown (not click) so selection commits before the input's blur fires.
+    event.preventDefault();
+    this.select(option);
+  }
+
+  protected onKeydown(event: KeyboardEvent): void {
+    if (this.isDisabled()) {
+      return;
+    }
+    const options = this.filtered();
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        if (!this.isOpen()) {
+          this.open();
+          return;
+        }
+        this.moveHighlight(1, options.length);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (!this.isOpen()) {
+          this.open();
+          return;
+        }
+        this.moveHighlight(-1, options.length);
+        break;
+      case 'Enter': {
+        if (!this.isOpen()) {
+          return;
+        }
+        event.preventDefault();
+        const index = this.highlightedIndex();
+        if (index >= 0 && index < options.length) {
+          this.select(options[index]);
+        }
+        break;
+      }
+      case 'Escape':
+        if (this.isOpen()) {
+          event.preventDefault();
+          this.close();
+        }
+        break;
+    }
+  }
+
+  protected onDocumentClick(event: Event): void {
+    if (!this.isOpen()) {
+      return;
+    }
+    if (!this.elementRef.nativeElement.contains(event.target as Node)) {
+      this.close();
+    }
+  }
+
+  private moveHighlight(direction: number, length: number): void {
+    if (length === 0) {
+      this.highlightedIndex.set(-1);
+      return;
+    }
+    let next = this.highlightedIndex() + direction;
+    if (next < 0) {
+      next = length - 1;
+    } else if (next >= length) {
+      next = 0;
+    }
+    this.highlightedIndex.set(next);
+  }
+
+  private select(option: ZardComboboxOption): void {
+    this.query.set(this.labelOf(option));
+    this.commit(option, true);
+    this.close();
+  }
+
+  // Sets the form value to the option's VALUE and notifies the form.
+  private commit(option: ZardComboboxOption, emit: boolean): void {
+    const value = this.valueOf(option);
+    this.selectedValue.set(value);
+    if (emit) {
+      this.onChange(value);
+    }
+    this.cdr.markForCheck();
+  }
+
+  private open(): void {
+    if (this.isOpen()) {
+      return;
+    }
+    this.isOpen.set(true);
+    const options = this.filtered();
+    const selectedIndex = options.findIndex(option => this.isSelected(option));
+    this.highlightedIndex.set(
+      selectedIndex >= 0 ? selectedIndex : options.length ? 0 : -1
+    );
+    this.cdr.markForCheck();
+  }
+
+  private close(): void {
+    if (!this.isOpen()) {
+      return;
+    }
+    this.isOpen.set(false);
+    this.highlightedIndex.set(-1);
+    this.cdr.markForCheck();
+  }
+
+  // ControlValueAccessor implementation
+  writeValue(value: unknown): void {
+    this.selectedValue.set(value ?? null);
+    const match = (this.zOptions() ?? []).find(
+      option => this.valueOf(option) === value
+    );
+    this.query.set(match ? this.labelOf(match) : '');
+    this.cdr.markForCheck();
+  }
+
+  registerOnChange(fn: OnChangeType): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: OnTouchedType): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    // Called by Angular forms (e.g. FormControl.disable()); combined with the
+    // disabled() input via the isDisabled computed.
+    this.formDisabled.set(isDisabled);
+    this.cdr.markForCheck();
+  }
+}

--- a/v2/ui/combobox/combobox.component.ts
+++ b/v2/ui/combobox/combobox.component.ts
@@ -26,6 +26,7 @@ import {
   ChangeDetectorRef,
   Component,
   computed,
+  effect,
   ElementRef,
   forwardRef,
   inject,
@@ -52,6 +53,9 @@ import {
 type OnTouchedType = () => void;
 type OnChangeType = (value: unknown) => void;
 
+// Per-instance id counter so multiple comboboxes on one page don't collide.
+let nextId = 0;
+
 export type ZardComboboxOption = string | Record<string, unknown>;
 
 @Component({
@@ -75,7 +79,7 @@ export type ZardComboboxOption = string | Record<string, unknown>;
         [disabled]="isDisabled()"
         [placeholder]="zPlaceholder()"
         [attr.aria-expanded]="isOpen()"
-        [attr.aria-controls]="isOpen() ? 'combobox-listbox' : null"
+        [attr.aria-controls]="isOpen() ? listboxId : null"
         [attr.aria-activedescendant]="activeDescendantId()"
         aria-autocomplete="list"
         (input)="onInput($event)"
@@ -85,7 +89,7 @@ export type ZardComboboxOption = string | Record<string, unknown>;
     </div>
 
     @if (isOpen()) {
-      <div id="combobox-listbox" role="listbox" [class]="contentClasses()">
+      <div [id]="listboxId" role="listbox" [class]="contentClasses()">
         @for (option of filtered(); track labelOf(option); let i = $index) {
           <div
             role="option"
@@ -131,6 +135,12 @@ export class ZardComboboxComponent implements ControlValueAccessor {
   private readonly cdr = inject(ChangeDetectorRef);
   private readonly elementRef = inject(ElementRef<HTMLElement>);
 
+  // Unique per-instance id base so multiple comboboxes on one page don't
+  // collide on listbox/option ids (which aria-controls/aria-activedescendant
+  // would otherwise resolve to the wrong element).
+  private readonly uid = nextId++;
+  protected readonly listboxId = `z-combobox-${this.uid}-listbox`;
+
   readonly class = input<ClassValue>('');
   readonly zOptions = input<ZardComboboxOption[]>([]);
   readonly zLabelKey = input<string>('label');
@@ -150,6 +160,28 @@ export class ZardComboboxComponent implements ControlValueAccessor {
 
   // The currently committed form value (the option's value, not its label).
   private readonly selectedValue = signal<unknown>(null);
+
+  // True while the user is actively typing/editing the input, so the
+  // label-resync effect won't clobber in-progress text.
+  private readonly isEditing = signal<boolean>(false);
+
+  constructor() {
+    // Keep the visible label in sync with the committed value once options
+    // resolve. Handles async options that arrive after writeValue() ran:
+    // writeValue() can't resolve a label from an empty zOptions(), so this
+    // effect fills it in when the matching option appears. Skips while the
+    // user is actively editing to avoid overwriting in-progress text.
+    effect(() => {
+      const value = this.selectedValue();
+      const options = this.zOptions() ?? [];
+      if (this.isEditing()) {
+        return;
+      }
+      const match = options.find(option => this.valueOf(option) === value);
+      this.query.set(match ? this.labelOf(match) : '');
+      this.cdr.markForCheck();
+    });
+  }
 
   /* eslint-disable-next-line @typescript-eslint/no-empty-function */
   private onChange: OnChangeType = () => {};
@@ -201,7 +233,7 @@ export class ZardComboboxComponent implements ControlValueAccessor {
   }
 
   protected optionId(index: number): string {
-    return `combobox-option-${index}`;
+    return `z-combobox-${this.uid}-option-${index}`;
   }
 
   protected itemClasses(index: number): string {
@@ -222,6 +254,7 @@ export class ZardComboboxComponent implements ControlValueAccessor {
       return;
     }
     const text = (event.target as HTMLInputElement).value;
+    this.isEditing.set(true);
     this.query.set(text);
     this.open();
     this.highlightedIndex.set(this.filtered().length ? 0 : -1);
@@ -244,6 +277,20 @@ export class ZardComboboxComponent implements ControlValueAccessor {
 
   protected onBlur(): void {
     this.onTouched();
+    // Defer so a click on an option (mousedown) commits its selection before
+    // we reconcile — otherwise we'd snap back to the old value first.
+    setTimeout(() => {
+      this.close();
+      // Done editing: snap the input text back to the committed option's label
+      // (or clear it when nothing is selected), discarding arbitrary typed text.
+      this.isEditing.set(false);
+      const value = this.selectedValue();
+      const match = (this.zOptions() ?? []).find(
+        option => this.valueOf(option) === value
+      );
+      this.query.set(match ? this.labelOf(match) : '');
+      this.cdr.markForCheck();
+    });
   }
 
   protected onOptionMousedown(event: Event, option: ZardComboboxOption): void {
@@ -319,6 +366,7 @@ export class ZardComboboxComponent implements ControlValueAccessor {
   }
 
   private select(option: ZardComboboxOption): void {
+    this.isEditing.set(false);
     this.query.set(this.labelOf(option));
     this.commit(option, true);
     this.close();
@@ -358,11 +406,10 @@ export class ZardComboboxComponent implements ControlValueAccessor {
 
   // ControlValueAccessor implementation
   writeValue(value: unknown): void {
+    // A programmatic write is never "the user editing"; let the resync effect
+    // resolve the visible label (handles options that load after this call).
+    this.isEditing.set(false);
     this.selectedValue.set(value ?? null);
-    const match = (this.zOptions() ?? []).find(
-      option => this.valueOf(option) === value
-    );
-    this.query.set(match ? this.labelOf(match) : '');
     this.cdr.markForCheck();
   }
 

--- a/v2/ui/combobox/combobox.variants.ts
+++ b/v2/ui/combobox/combobox.variants.ts
@@ -1,0 +1,37 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva } from 'class-variance-authority';
+
+export const comboboxVariants = cva('relative block w-full');
+
+export const comboboxContentVariants = cva(
+  'absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md'
+);
+
+export const comboboxItemVariants = cva(
+  'relative flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground'
+);
+
+export const comboboxItemIconVariants = cva(
+  'mr-2 flex size-3.5 items-center justify-center'
+);

--- a/v2/ui/combobox/index.ts
+++ b/v2/ui/combobox/index.ts
@@ -1,0 +1,24 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './combobox.component';
+export * from './combobox.variants';

--- a/v2/ui/radio-group/index.ts
+++ b/v2/ui/radio-group/index.ts
@@ -1,0 +1,24 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './radio-group.component';
+export * from './radio-group.variants';

--- a/v2/ui/radio-group/radio-group.component.ts
+++ b/v2/ui/radio-group/radio-group.component.ts
@@ -116,6 +116,12 @@ export class ZardRadioGroupComponent implements ControlValueAccessor {
     return this.value() === value;
   }
 
+  /** Called by a child radio on blur so the control is marked touched even
+   * when selection didn't change. */
+  markAsTouched(): void {
+    this.onTouched();
+  }
+
   writeValue(value: unknown): void {
     this.value.set(value);
     this.cdr.markForCheck();

--- a/v2/ui/radio-group/radio-group.component.ts
+++ b/v2/ui/radio-group/radio-group.component.ts
@@ -1,0 +1,136 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  computed,
+  forwardRef,
+  inject,
+  input,
+  output,
+  signal,
+  ViewEncapsulation,
+} from '@angular/core';
+import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import {
+  radioGroupVariants,
+  type ZardRadioGroupVariants,
+} from './radio-group.variants';
+
+type OnTouchedType = () => unknown;
+type OnChangeType = (value: unknown) => void;
+
+let uniqueGroupId = 0;
+
+/**
+ * Radio group: owns the selected value (and the form binding via
+ * ControlValueAccessor) and coordinates the `z-radio` items projected into
+ * it. Each child radio reads `value()` for its checked state and calls
+ * `select()` when chosen, so a single `formControlName` on the group drives
+ * the whole set — the shadcn RadioGroup + RadioGroupItem pattern.
+ */
+@Component({
+  selector: 'z-radio-group, [z-radio-group]',
+  template: `<ng-content />`,
+  host: {
+    role: 'radiogroup',
+    '[class]': 'classes()',
+    '[attr.aria-orientation]': 'zOrientation()',
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ZardRadioGroupComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zRadioGroup',
+})
+export class ZardRadioGroupComponent implements ControlValueAccessor {
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  readonly class = input<ClassValue>('');
+  readonly zOrientation =
+    input<ZardRadioGroupVariants['zOrientation']>('vertical');
+  readonly name = input<string>(`z-radio-group-${uniqueGroupId++}`);
+  readonly disabled = input(false, { transform: booleanAttribute });
+  readonly zChange = output<unknown>();
+
+  /** Currently selected value; read by the child radios for `checked`. */
+  readonly value = signal<unknown>(null);
+
+  private readonly formDisabled = signal(false);
+  readonly isDisabled = computed(() => this.disabled() || this.formDisabled());
+
+  protected readonly classes = computed(() =>
+    mergeClasses(
+      radioGroupVariants({ zOrientation: this.zOrientation() }),
+      this.class()
+    )
+  );
+
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+  private onChange: OnChangeType = () => {};
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+  private onTouched: OnTouchedType = () => {};
+
+  /** Called by a child radio when picked. */
+  select(value: unknown): void {
+    if (this.isDisabled()) return;
+    this.value.set(value);
+    this.onChange(value);
+    this.onTouched();
+    this.zChange.emit(value);
+  }
+
+  isSelected(value: unknown): boolean {
+    return this.value() === value;
+  }
+
+  writeValue(value: unknown): void {
+    this.value.set(value);
+    this.cdr.markForCheck();
+  }
+
+  registerOnChange(fn: OnChangeType): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: OnTouchedType): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(disabledState: boolean): void {
+    this.formDisabled.set(disabledState);
+    this.cdr.markForCheck();
+  }
+}

--- a/v2/ui/radio-group/radio-group.variants.ts
+++ b/v2/ui/radio-group/radio-group.variants.ts
@@ -1,0 +1,37 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const radioGroupVariants = cva('flex gap-3', {
+  variants: {
+    zOrientation: {
+      vertical: 'flex-col',
+      horizontal: 'flex-row flex-wrap items-center gap-x-6 gap-y-2',
+    },
+  },
+  defaultVariants: {
+    zOrientation: 'vertical',
+  },
+});
+
+export type ZardRadioGroupVariants = VariantProps<typeof radioGroupVariants>;

--- a/v2/ui/radio/radio.component.ts
+++ b/v2/ui/radio/radio.component.ts
@@ -39,6 +39,7 @@ import type { ClassValue } from 'clsx';
 
 import { ZardIdDirective } from '../directives';
 import { mergeClasses } from '../utils/merge-classes';
+import { ZardRadioGroupComponent } from '../radio-group/radio-group.component';
 
 import { radioLabelVariants, radioVariants } from './radio.variants';
 
@@ -53,23 +54,20 @@ type OnChangeType = (value: unknown) => void;
       class="relative flex items-center gap-2"
       [class]="isDisabled() ? 'cursor-not-allowed' : 'cursor-pointer'"
       zardId="radio"
-      #z="zardId"
-    >
+      #z="zardId">
       <input
         #input
         type="radio"
         [value]="value()"
         [class]="classes()"
-        [checked]="checked"
+        [checked]="isChecked()"
         [disabled]="isDisabled()"
         (change)="onRadioChange()"
         (blur)="onRadioBlur()"
-        [name]="name()"
-        [id]="zId() || z.id()"
-      />
+        [name]="resolvedName()"
+        [id]="zId() || z.id()" />
       <span
-        class="bg-primary pointer-events-none absolute left-1 size-2 rounded-full opacity-0 peer-checked:opacity-100"
-      ></span>
+        class="bg-primary pointer-events-none absolute left-1 size-2 rounded-full opacity-0 peer-checked:opacity-100"></span>
       <label [class]="labelClasses()" [for]="zId() || z.id()">
         <ng-content />
       </label>
@@ -88,6 +86,9 @@ type OnChangeType = (value: unknown) => void;
 })
 export class ZardRadioComponent implements ControlValueAccessor {
   private readonly cdr = inject(ChangeDetectorRef);
+  // Optional parent group: when present it owns the selected value and the
+  // form binding, and this radio reflects/updates it instead of its own CVA.
+  private readonly group = inject(ZardRadioGroupComponent, { optional: true });
 
   readonly radioChange = output<boolean>();
   readonly class = input<ClassValue>('');
@@ -101,17 +102,32 @@ export class ZardRadioComponent implements ControlValueAccessor {
   /* eslint-disable-next-line @typescript-eslint/no-empty-function */
   private onTouched: OnTouchedType = () => {};
 
-  protected readonly classes = computed(() => mergeClasses(radioVariants(), this.class()));
-  protected readonly labelClasses = computed(() => mergeClasses(radioLabelVariants()));
+  protected readonly classes = computed(() =>
+    mergeClasses(radioVariants(), this.class())
+  );
+  protected readonly labelClasses = computed(() =>
+    mergeClasses(radioLabelVariants())
+  );
 
   // Form-driven disabled state (FormControl.disable()), combined with the input.
   private readonly formDisabled = signal(false);
-  protected readonly isDisabled = computed(() => this.disabled() || this.formDisabled());
+  protected readonly isDisabled = computed(
+    () => this.group?.isDisabled() || this.disabled() || this.formDisabled()
+  );
 
-  checked = false;
+  // Checked state: from the parent group when grouped, else from this radio's
+  // own CVA value (standalone use).
+  private readonly standaloneChecked = signal(false);
+  protected readonly isChecked = computed(() =>
+    this.group ? this.group.isSelected(this.value()) : this.standaloneChecked()
+  );
+  // Grouped radios share the group's name so the browser treats them as one set.
+  protected readonly resolvedName = computed(
+    () => this.group?.name() ?? this.name()
+  );
 
   writeValue(val: unknown): void {
-    this.checked = val === this.value();
+    this.standaloneChecked.set(val === this.value());
     this.cdr.markForCheck();
   }
 
@@ -140,9 +156,13 @@ export class ZardRadioComponent implements ControlValueAccessor {
       return;
     }
 
-    this.checked = true;
-    this.onChange(this.value());
-    this.radioChange.emit(this.checked);
+    if (this.group) {
+      this.group.select(this.value());
+    } else {
+      this.standaloneChecked.set(true);
+      this.onChange(this.value());
+    }
+    this.radioChange.emit(true);
     this.cdr.markForCheck();
   }
 }

--- a/v2/ui/radio/radio.component.ts
+++ b/v2/ui/radio/radio.component.ts
@@ -148,6 +148,7 @@ export class ZardRadioComponent implements ControlValueAccessor {
 
   onRadioBlur(): void {
     this.onTouched();
+    this.group?.markAsTouched();
     this.cdr.markForCheck();
   }
 

--- a/v2/ui/sheet/index.ts
+++ b/v2/ui/sheet/index.ts
@@ -1,0 +1,24 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './sheet.component';
+export * from './sheet.variants';

--- a/v2/ui/sheet/sheet.component.ts
+++ b/v2/ui/sheet/sheet.component.ts
@@ -162,13 +162,13 @@ export class ZardSheetComponent {
     }
 
     const first = focusable[0];
-    const last = focusable[focusable.length - 1];
+    const last = focusable.at(-1);
     const active = this.document.activeElement;
 
     if (event.shiftKey) {
       if (active === first || active === panelEl) {
         event.preventDefault();
-        last.focus();
+        last?.focus();
       }
     } else if (active === last) {
       event.preventDefault();

--- a/v2/ui/sheet/sheet.component.ts
+++ b/v2/ui/sheet/sheet.component.ts
@@ -1,0 +1,104 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  model,
+  ViewEncapsulation,
+} from '@angular/core';
+
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideX } from '@ng-icons/lucide';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import {
+  sheetClosedTransform,
+  sheetVariants,
+  type ZardSheetVariants,
+} from './sheet.variants';
+
+@Component({
+  selector: 'z-sheet, [z-sheet]',
+  imports: [NgIcon],
+  template: `
+    @if (zOpen()) {
+      <!-- Backdrop -->
+      <div
+        class="fixed inset-0 z-50 bg-black/50 transition-opacity"
+        (click)="close()"></div>
+
+      <!-- Panel -->
+      <div [class]="panelClasses()" role="dialog" aria-modal="true">
+        <header class="flex items-center justify-between gap-4">
+          @if (zTitle()) {
+            <p class="text-lg font-semibold text-foreground">{{ zTitle() }}</p>
+          }
+          <button
+            type="button"
+            aria-label="Close"
+            class="appearance-none border-0 bg-transparent ml-auto inline-flex items-center justify-center rounded-sm opacity-70 transition-opacity hover:opacity-100 cursor-pointer"
+            (click)="close()">
+            <ng-icon name="lucideX" size="1rem" />
+          </button>
+        </header>
+
+        <ng-content />
+      </div>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  viewProviders: [provideIcons({ lucideX })],
+  exportAs: 'zSheet',
+  host: {
+    '[class]': 'classes()',
+    '(keydown.escape)': 'close()',
+  },
+})
+export class ZardSheetComponent {
+  readonly zSide = input<NonNullable<ZardSheetVariants['zSide']>>('right');
+  readonly zOpen = model<boolean>(false);
+  readonly zTitle = input<string>('');
+  readonly class = input<ClassValue>('');
+
+  protected readonly classes = computed(() =>
+    mergeClasses('contents', this.class())
+  );
+
+  protected readonly panelClasses = computed(() =>
+    mergeClasses(
+      sheetVariants({ zSide: this.zSide() }),
+      // Open => slid into place (no transform); closed => off-screen.
+      this.zOpen() ? '' : sheetClosedTransform({ zSide: this.zSide() })
+    )
+  );
+
+  close(): void {
+    this.zOpen.set(false);
+  }
+}

--- a/v2/ui/sheet/sheet.component.ts
+++ b/v2/ui/sheet/sheet.component.ts
@@ -20,12 +20,17 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
+import { DOCUMENT } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
+  ElementRef,
+  inject,
   input,
   model,
+  viewChild,
   ViewEncapsulation,
 } from '@angular/core';
 
@@ -38,6 +43,7 @@ import { mergeClasses } from '../utils/merge-classes';
 
 import {
   sheetClosedTransform,
+  sheetOpenTransform,
   sheetVariants,
   type ZardSheetVariants,
 } from './sheet.variants';
@@ -46,30 +52,32 @@ import {
   selector: 'z-sheet, [z-sheet]',
   imports: [NgIcon],
   template: `
-    @if (zOpen()) {
-      <!-- Backdrop -->
-      <div
-        class="fixed inset-0 z-50 bg-black/50 transition-opacity"
-        (click)="close()"></div>
+    <!-- Backdrop: always mounted; fades in/out so close animates too. -->
+    <div [class]="backdropClasses()" (click)="close()"></div>
 
-      <!-- Panel -->
-      <div [class]="panelClasses()" role="dialog" aria-modal="true">
-        <header class="flex items-center justify-between gap-4">
-          @if (zTitle()) {
-            <p class="text-lg font-semibold text-foreground">{{ zTitle() }}</p>
-          }
-          <button
-            type="button"
-            aria-label="Close"
-            class="appearance-none border-0 bg-transparent ml-auto inline-flex items-center justify-center rounded-sm opacity-70 transition-opacity hover:opacity-100 cursor-pointer"
-            (click)="close()">
-            <ng-icon name="lucideX" size="1rem" />
-          </button>
-        </header>
+    <!-- Panel: always mounted; slides via transition-transform on open/close. -->
+    <div
+      #panel
+      [class]="panelClasses()"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      (keydown.tab)="onTab($event)">
+      <header class="flex items-center justify-between gap-4">
+        @if (zTitle()) {
+          <p class="text-lg font-semibold text-foreground">{{ zTitle() }}</p>
+        }
+        <button
+          type="button"
+          aria-label="Close"
+          class="appearance-none border-0 bg-transparent ml-auto inline-flex items-center justify-center rounded-sm opacity-70 transition-opacity hover:opacity-100 cursor-pointer"
+          (click)="close()">
+          <ng-icon name="lucideX" size="1rem" />
+        </button>
+      </header>
 
-        <ng-content />
-      </div>
-    }
+      <ng-content />
+    </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
@@ -81,22 +89,101 @@ import {
   },
 })
 export class ZardSheetComponent {
+  private readonly document = inject(DOCUMENT);
+
   readonly zSide = input<NonNullable<ZardSheetVariants['zSide']>>('right');
   readonly zOpen = model<boolean>(false);
   readonly zTitle = input<string>('');
   readonly class = input<ClassValue>('');
 
+  private readonly panel = viewChild<ElementRef<HTMLElement>>('panel');
+
+  /** Element focused before the sheet opened, restored on close. */
+  private previouslyFocused: HTMLElement | null = null;
+
   protected readonly classes = computed(() =>
     mergeClasses('contents', this.class())
+  );
+
+  protected readonly backdropClasses = computed(() =>
+    mergeClasses(
+      'fixed inset-0 z-50 bg-black/50 transition-opacity',
+      this.zOpen()
+        ? 'opacity-100 pointer-events-auto'
+        : 'opacity-0 pointer-events-none'
+    )
   );
 
   protected readonly panelClasses = computed(() =>
     mergeClasses(
       sheetVariants({ zSide: this.zSide() }),
-      // Open => slid into place (no transform); closed => off-screen.
-      this.zOpen() ? '' : sheetClosedTransform({ zSide: this.zSide() })
+      // Always mounted: open => slid into place, closed => off-screen, so the
+      // transition-transform animates both directions.
+      this.zOpen()
+        ? `${sheetOpenTransform({ zSide: this.zSide() })} pointer-events-auto`
+        : `${sheetClosedTransform({ zSide: this.zSide() })} pointer-events-none`
     )
   );
+
+  constructor() {
+    // Move focus into the sheet on open and restore it on close.
+    effect(() => {
+      const open = this.zOpen();
+      const panelEl = this.panel()?.nativeElement;
+      if (!panelEl) {
+        return;
+      }
+      if (open) {
+        this.previouslyFocused = this.document
+          .activeElement as HTMLElement | null;
+        // Focus the first focusable element, falling back to the panel itself.
+        const focusable = this.getFocusableElements(panelEl);
+        (focusable[0] ?? panelEl).focus();
+      } else if (this.previouslyFocused) {
+        this.previouslyFocused.focus();
+        this.previouslyFocused = null;
+      }
+    });
+  }
+
+  /** Basic focus trap: wrap focus within the panel on Tab / Shift+Tab. */
+  protected onTab(rawEvent: Event): void {
+    const event = rawEvent as KeyboardEvent;
+    const panelEl = this.panel()?.nativeElement;
+    if (!panelEl) {
+      return;
+    }
+
+    const focusable = this.getFocusableElements(panelEl);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      panelEl.focus();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = this.document.activeElement;
+
+    if (event.shiftKey) {
+      if (active === first || active === panelEl) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  private getFocusableElements(container: HTMLElement): HTMLElement[] {
+    const selector =
+      'a[href], button:not([disabled]), textarea:not([disabled]), ' +
+      'input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    return Array.from(container.querySelectorAll<HTMLElement>(selector)).filter(
+      el => el.offsetParent !== null || el === container
+    );
+  }
 
   close(): void {
     this.zOpen.set(false);

--- a/v2/ui/sheet/sheet.variants.ts
+++ b/v2/ui/sheet/sheet.variants.ts
@@ -1,0 +1,59 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const sheetVariants = cva(
+  'fixed z-50 bg-background p-6 shadow-lg flex flex-col gap-4 transition-transform duration-300 ease-in-out',
+  {
+    variants: {
+      zSide: {
+        right: 'inset-y-0 right-0 h-full w-3/4 max-w-sm border-l',
+        left: 'inset-y-0 left-0 h-full w-3/4 max-w-sm border-r',
+        top: 'inset-x-0 top-0 h-auto w-full border-b',
+        bottom: 'inset-x-0 bottom-0 h-auto w-full border-t',
+      },
+    },
+    defaultVariants: {
+      zSide: 'right',
+    },
+  }
+);
+export type ZardSheetVariants = VariantProps<typeof sheetVariants>;
+
+/**
+ * Closed-state transform per side: panel is translated fully off-screen so the
+ * `transition-transform` on the panel produces a slide-in/out effect.
+ */
+export const sheetClosedTransform = cva('', {
+  variants: {
+    zSide: {
+      right: 'translate-x-full',
+      left: '-translate-x-full',
+      top: '-translate-y-full',
+      bottom: 'translate-y-full',
+    },
+  },
+  defaultVariants: {
+    zSide: 'right',
+  },
+});

--- a/v2/ui/sheet/sheet.variants.ts
+++ b/v2/ui/sheet/sheet.variants.ts
@@ -57,3 +57,21 @@ export const sheetClosedTransform = cva('', {
     zSide: 'right',
   },
 });
+
+/**
+ * Open-state transform per side: panel is slid into place along the relevant
+ * axis, complementing {@link sheetClosedTransform} so the slide animates.
+ */
+export const sheetOpenTransform = cva('', {
+  variants: {
+    zSide: {
+      right: 'translate-x-0',
+      left: 'translate-x-0',
+      top: 'translate-y-0',
+      bottom: 'translate-y-0',
+    },
+  },
+  defaultVariants: {
+    zSide: 'right',
+  },
+});

--- a/v2/ui/stepper/index.ts
+++ b/v2/ui/stepper/index.ts
@@ -1,0 +1,25 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './stepper.component';
+export * from './stepper.variants';
+export * from './stepper.imports';

--- a/v2/ui/stepper/stepper.component.ts
+++ b/v2/ui/stepper/stepper.component.ts
@@ -50,7 +50,7 @@ import {
   template: `<ng-content />`,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  host: { '[class]': 'classes()' },
+  host: { '[class]': 'classes()', role: 'list' },
 })
 export class ZardStepperComponent {
   // 0-based index of the currently active step.
@@ -60,6 +60,14 @@ export class ZardStepperComponent {
   // Steps register themselves via projection; this gives their document order,
   // which a step uses to resolve its own index (see ZardStepComponent.index()).
   readonly steps = contentChildren(ZardStepComponent);
+
+  // The raw zActiveIndex may be out of bounds (e.g. -1 or >= length). Clamp it
+  // into a valid range so exactly one step is "active" — an out-of-range value
+  // would otherwise make every step upcoming (-1) or completed (>= length).
+  // Guard for an empty stepper so the lower bound never goes negative.
+  readonly activeIndex = computed(() =>
+    Math.max(0, Math.min(this.zActiveIndex(), this.steps().length - 1))
+  );
 
   protected readonly classes = computed(() =>
     mergeClasses(stepperVariants(), this.class())
@@ -72,7 +80,7 @@ export class ZardStepperComponent {
   imports: [NgIcon],
   viewProviders: [provideIcons({ lucideCheck })],
   template: `
-    <span [class]="indicatorClasses()">
+    <span [class]="indicatorClasses()" aria-hidden="true">
       @if (state() === 'completed') {
         <ng-icon name="lucideCheck" />
       } @else {
@@ -81,16 +89,22 @@ export class ZardStepperComponent {
     </span>
 
     @if (zLabel()) {
-      <span [class]="labelClasses()">{{ zLabel() }}</span>
+      <span [class]="labelClasses()" aria-hidden="true">{{ zLabel() }}</span>
     }
 
+    <span class="sr-only">{{ a11yLabel() }}</span>
+
     @if (!isLast()) {
-      <span [class]="connectorClasses()"></span>
+      <span [class]="connectorClasses()" aria-hidden="true"></span>
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
-  host: { '[class]': 'classes()' },
+  host: {
+    '[class]': 'classes()',
+    role: 'listitem',
+    '[attr.aria-current]': "state() === 'active' ? 'step' : null",
+  },
 })
 export class ZardStepComponent {
   // The parent stepper owns the active index and the ordered list of steps.
@@ -105,7 +119,9 @@ export class ZardStepComponent {
   protected readonly index = computed(() => this.stepper.steps().indexOf(this));
 
   protected readonly state = computed<ZardStepState>(() => {
-    const active = this.stepper.zActiveIndex();
+    // Use the parent's clamped active index so an out-of-range zActiveIndex
+    // can't make every step upcoming/completed.
+    const active = this.stepper.activeIndex();
     const index = this.index();
     if (index < active) {
       return 'completed';
@@ -114,6 +130,19 @@ export class ZardStepComponent {
       return 'active';
     }
     return 'upcoming';
+  });
+
+  // Visually-hidden status announced to screen readers, e.g.
+  // "Step 2: Vitals — current". The visible indicator/label are aria-hidden.
+  protected readonly a11yLabel = computed(() => {
+    const stateText =
+      this.state() === 'completed'
+        ? 'completed'
+        : this.state() === 'active'
+          ? 'current'
+          : 'upcoming';
+    const label = this.zLabel();
+    return `Step ${this.index() + 1}${label ? ': ' + label : ''} — ${stateText}`;
   });
 
   protected readonly isLast = computed(

--- a/v2/ui/stepper/stepper.component.ts
+++ b/v2/ui/stepper/stepper.component.ts
@@ -1,0 +1,140 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  contentChildren,
+  inject,
+  input,
+  ViewEncapsulation,
+} from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideCheck } from '@ng-icons/lucide';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+import {
+  stepConnectorVariants,
+  stepIndicatorVariants,
+  stepLabelVariants,
+  stepperVariants,
+  stepVariants,
+  type ZardStepState,
+} from './stepper.variants';
+
+@Component({
+  selector: 'z-stepper, [z-stepper]',
+  exportAs: 'zStepper',
+  template: `<ng-content />`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+})
+export class ZardStepperComponent {
+  // 0-based index of the currently active step.
+  readonly zActiveIndex = input<number>(0);
+  readonly class = input<ClassValue>('');
+
+  // Steps register themselves via projection; this gives their document order,
+  // which a step uses to resolve its own index (see ZardStepComponent.index()).
+  readonly steps = contentChildren(ZardStepComponent);
+
+  protected readonly classes = computed(() =>
+    mergeClasses(stepperVariants(), this.class())
+  );
+}
+
+@Component({
+  selector: 'z-step, [z-step]',
+  exportAs: 'zStep',
+  imports: [NgIcon],
+  viewProviders: [provideIcons({ lucideCheck })],
+  template: `
+    <span [class]="indicatorClasses()">
+      @if (state() === 'completed') {
+        <ng-icon name="lucideCheck" />
+      } @else {
+        {{ index() + 1 }}
+      }
+    </span>
+
+    @if (zLabel()) {
+      <span [class]="labelClasses()">{{ zLabel() }}</span>
+    }
+
+    @if (!isLast()) {
+      <span [class]="connectorClasses()"></span>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: { '[class]': 'classes()' },
+})
+export class ZardStepComponent {
+  // The parent stepper owns the active index and the ordered list of steps.
+  private readonly stepper = inject(ZardStepperComponent);
+
+  readonly zLabel = input<string>('');
+  readonly class = input<ClassValue>('');
+
+  // Resolve this step's position from the parent's projected-children order —
+  // same approach as tabs.component.ts (tabs()[index]); here we look ourselves
+  // up with indexOf(this) so each step knows where it sits.
+  protected readonly index = computed(() => this.stepper.steps().indexOf(this));
+
+  protected readonly state = computed<ZardStepState>(() => {
+    const active = this.stepper.zActiveIndex();
+    const index = this.index();
+    if (index < active) {
+      return 'completed';
+    }
+    if (index === active) {
+      return 'active';
+    }
+    return 'upcoming';
+  });
+
+  protected readonly isLast = computed(
+    () => this.index() === this.stepper.steps().length - 1
+  );
+
+  protected readonly classes = computed(() =>
+    mergeClasses(
+      stepVariants({ zState: this.state(), zLast: this.isLast() }),
+      this.class()
+    )
+  );
+  protected readonly indicatorClasses = computed(() =>
+    mergeClasses(stepIndicatorVariants({ zState: this.state() }))
+  );
+  protected readonly labelClasses = computed(() =>
+    mergeClasses(stepLabelVariants({ zState: this.state() }))
+  );
+  protected readonly connectorClasses = computed(() =>
+    mergeClasses(
+      stepConnectorVariants({ zCompleted: this.state() === 'completed' })
+    )
+  );
+}

--- a/v2/ui/stepper/stepper.component.ts
+++ b/v2/ui/stepper/stepper.component.ts
@@ -134,15 +134,15 @@ export class ZardStepComponent {
 
   // Visually-hidden status announced to screen readers, e.g.
   // "Step 2: Vitals — current". The visible indicator/label are aria-hidden.
+  private readonly stateText: Record<ZardStepState, string> = {
+    completed: 'completed',
+    active: 'current',
+    upcoming: 'upcoming',
+  };
+
   protected readonly a11yLabel = computed(() => {
-    const stateText =
-      this.state() === 'completed'
-        ? 'completed'
-        : this.state() === 'active'
-          ? 'current'
-          : 'upcoming';
     const label = this.zLabel();
-    return `Step ${this.index() + 1}${label ? ': ' + label : ''} — ${stateText}`;
+    return `Step ${this.index() + 1}${label ? ': ' + label : ''} — ${this.stateText[this.state()]}`;
   });
 
   protected readonly isLast = computed(

--- a/v2/ui/stepper/stepper.imports.ts
+++ b/v2/ui/stepper/stepper.imports.ts
@@ -1,0 +1,28 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { ZardStepComponent, ZardStepperComponent } from './stepper.component';
+
+export const ZardStepperImports = [
+  ZardStepperComponent,
+  ZardStepComponent,
+] as const;

--- a/v2/ui/stepper/stepper.variants.ts
+++ b/v2/ui/stepper/stepper.variants.ts
@@ -1,0 +1,89 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const stepperVariants = cva('flex w-full items-center');
+
+export const stepVariants = cva('flex items-center', {
+  variants: {
+    zState: {
+      completed: '',
+      active: '',
+      upcoming: '',
+    },
+    // Non-last steps grow so their trailing connector line fills the gap;
+    // the last step hugs its content so it sits flush at the end.
+    zLast: {
+      true: 'shrink-0',
+      false: 'flex-1',
+    },
+  },
+  defaultVariants: {
+    zState: 'upcoming',
+    zLast: false,
+  },
+});
+
+export const stepIndicatorVariants = cva(
+  'flex size-8 items-center justify-center rounded-full border text-sm font-medium transition-colors',
+  {
+    variants: {
+      zState: {
+        completed: 'bg-primary text-primary-foreground border-primary',
+        active: 'border-primary text-primary',
+        upcoming: 'border-input text-muted-foreground',
+      },
+    },
+    defaultVariants: {
+      zState: 'upcoming',
+    },
+  }
+);
+
+export const stepLabelVariants = cva('ml-2 text-sm', {
+  variants: {
+    zState: {
+      completed: 'text-foreground',
+      active: 'text-foreground',
+      upcoming: 'text-muted-foreground',
+    },
+  },
+  defaultVariants: {
+    zState: 'upcoming',
+  },
+});
+
+export const stepConnectorVariants = cva('mx-2 h-px flex-1', {
+  variants: {
+    zCompleted: {
+      true: 'bg-primary',
+      false: 'bg-border',
+    },
+  },
+  defaultVariants: {
+    zCompleted: false,
+  },
+});
+
+export type ZardStepState = 'completed' | 'active' | 'upcoming';
+export type ZardStepVariants = VariantProps<typeof stepVariants>;

--- a/v2/ui/toggle-group/index.ts
+++ b/v2/ui/toggle-group/index.ts
@@ -1,0 +1,25 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './toggle-group.component';
+export * from './toggle-group.variants';
+export * from './toggle-group.imports';

--- a/v2/ui/toggle-group/toggle-group.component.ts
+++ b/v2/ui/toggle-group/toggle-group.component.ts
@@ -1,0 +1,198 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  computed,
+  forwardRef,
+  inject,
+  input,
+  output,
+  signal,
+  ViewEncapsulation,
+} from '@angular/core';
+import { type ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+import type { ClassValue } from 'clsx';
+
+import { mergeClasses } from '../utils/merge-classes';
+
+import {
+  toggleGroupItemVariants,
+  toggleGroupVariants,
+} from './toggle-group.variants';
+
+type OnTouchedType = () => unknown;
+type OnChangeType = (value: unknown) => void;
+
+export type ZardToggleGroupType = 'single' | 'multiple';
+
+/**
+ * Toggle group (segmented buttons): owns the selected value (and the form
+ * binding via ControlValueAccessor) and coordinates the
+ * `z-toggle-group-item` buttons projected into it. In 'single' mode the value
+ * is a single value (or null); in 'multiple' mode it is an array of values.
+ * Each child item reads `isSelected()` for its pressed state and calls
+ * `toggle()` when clicked — the shadcn ToggleGroup + ToggleGroupItem pattern.
+ */
+@Component({
+  selector: 'z-toggle-group, [z-toggle-group]',
+  template: `<ng-content />`,
+  host: {
+    role: 'group',
+    '[class]': 'classes()',
+  },
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ZardToggleGroupComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zToggleGroup',
+})
+export class ZardToggleGroupComponent implements ControlValueAccessor {
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  readonly class = input<ClassValue>('');
+  readonly zType = input<ZardToggleGroupType>('single');
+  readonly disabled = input(false, { transform: booleanAttribute });
+  readonly zChange = output<unknown>();
+
+  /** Currently selected value(s); read by the child items for `isOn`. */
+  readonly value = signal<unknown>(null);
+
+  private readonly formDisabled = signal(false);
+  readonly isDisabled = computed(() => this.disabled() || this.formDisabled());
+
+  protected readonly classes = computed(() =>
+    mergeClasses(toggleGroupVariants(), this.class())
+  );
+
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+  private onChange: OnChangeType = () => {};
+  /* eslint-disable-next-line @typescript-eslint/no-empty-function */
+  private onTouched: OnTouchedType = () => {};
+
+  /** Called by a child item when clicked. */
+  toggle(value: unknown): void {
+    if (this.isDisabled()) return;
+
+    let next: unknown;
+    if (this.zType() === 'multiple') {
+      const current = Array.isArray(this.value())
+        ? [...(this.value() as unknown[])]
+        : [];
+      const index = current.indexOf(value);
+      if (index === -1) {
+        current.push(value);
+      } else {
+        current.splice(index, 1);
+      }
+      next = current;
+    } else {
+      next = this.value() === value ? null : value;
+    }
+
+    this.value.set(next);
+    this.onChange(next);
+    this.onTouched();
+    this.zChange.emit(next);
+  }
+
+  isSelected(value: unknown): boolean {
+    const current = this.value();
+    if (this.zType() === 'multiple') {
+      return Array.isArray(current) && current.includes(value);
+    }
+    return current === value;
+  }
+
+  writeValue(value: unknown): void {
+    this.value.set(value);
+    this.cdr.markForCheck();
+  }
+
+  registerOnChange(fn: OnChangeType): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: OnTouchedType): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(disabledState: boolean): void {
+    this.formDisabled.set(disabledState);
+    this.cdr.markForCheck();
+  }
+}
+
+/**
+ * A single segmented button inside a `z-toggle-group`. Reads/updates the
+ * parent group: it reflects the group's selection via `aria-pressed` and
+ * `data-state`, and calls `group.toggle(zValue)` when clicked.
+ */
+@Component({
+  selector: 'z-toggle-group-item, [z-toggle-group-item]',
+  template: `
+    <button
+      type="button"
+      [class]="classes()"
+      [disabled]="isDisabled()"
+      [attr.aria-pressed]="isOn()"
+      [attr.data-state]="isOn() ? 'on' : 'off'"
+      (click)="onClick()">
+      <ng-content />
+    </button>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  exportAs: 'zToggleGroupItem',
+})
+export class ZardToggleGroupItemComponent {
+  private readonly group = inject(ZardToggleGroupComponent);
+
+  readonly class = input<ClassValue>('');
+  readonly zValue = input.required<unknown>();
+  readonly disabled = input(false, { transform: booleanAttribute });
+
+  protected readonly isOn = computed(() =>
+    this.group.isSelected(this.zValue())
+  );
+  protected readonly isDisabled = computed(
+    () => this.group.isDisabled() || this.disabled()
+  );
+
+  protected readonly classes = computed(() =>
+    mergeClasses(toggleGroupItemVariants({ isOn: this.isOn() }), this.class())
+  );
+
+  protected onClick(): void {
+    if (this.isDisabled()) return;
+    this.group.toggle(this.zValue());
+  }
+}

--- a/v2/ui/toggle-group/toggle-group.component.ts
+++ b/v2/ui/toggle-group/toggle-group.component.ts
@@ -133,7 +133,23 @@ export class ZardToggleGroupComponent implements ControlValueAccessor {
   }
 
   writeValue(value: unknown): void {
-    this.value.set(value);
+    let normalized: unknown;
+    if (this.zType() === 'multiple') {
+      if (Array.isArray(value)) {
+        normalized = value;
+      } else if (value === null || value === undefined) {
+        normalized = [];
+      } else {
+        normalized = [value];
+      }
+    } else {
+      if (Array.isArray(value)) {
+        normalized = value.length > 0 ? value[0] : null;
+      } else {
+        normalized = value ?? null;
+      }
+    }
+    this.value.set(normalized);
     this.cdr.markForCheck();
   }
 

--- a/v2/ui/toggle-group/toggle-group.component.ts
+++ b/v2/ui/toggle-group/toggle-group.component.ts
@@ -142,12 +142,10 @@ export class ZardToggleGroupComponent implements ControlValueAccessor {
       } else {
         normalized = [value];
       }
+    } else if (Array.isArray(value)) {
+      normalized = value.length > 0 ? value[0] : null;
     } else {
-      if (Array.isArray(value)) {
-        normalized = value.length > 0 ? value[0] : null;
-      } else {
-        normalized = value ?? null;
-      }
+      normalized = value ?? null;
     }
     this.value.set(normalized);
     this.cdr.markForCheck();

--- a/v2/ui/toggle-group/toggle-group.imports.ts
+++ b/v2/ui/toggle-group/toggle-group.imports.ts
@@ -1,0 +1,31 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  ZardToggleGroupComponent,
+  ZardToggleGroupItemComponent,
+} from './toggle-group.component';
+
+export const ZardToggleGroupImports = [
+  ZardToggleGroupComponent,
+  ZardToggleGroupItemComponent,
+] as const;

--- a/v2/ui/toggle-group/toggle-group.variants.ts
+++ b/v2/ui/toggle-group/toggle-group.variants.ts
@@ -1,0 +1,43 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+export const toggleGroupVariants = cva(
+  'inline-flex items-center justify-center gap-1 rounded-lg'
+);
+
+export const toggleGroupItemVariants = cva(
+  'inline-flex items-center justify-center rounded-md px-3 h-9 text-sm font-medium transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      isOn: {
+        true: 'bg-accent text-accent-foreground',
+      },
+    },
+  }
+);
+
+export type ZardToggleGroupVariants = VariantProps<typeof toggleGroupVariants>;
+export type ZardToggleGroupItemVariants = VariantProps<
+  typeof toggleGroupItemVariants
+>;


### PR DESCRIPTION
## What

Adds the seven Zard UI primitives that the remaining MMU screens need to migrate off Angular Material. All are shadcn-faithful, standalone (Angular 20), OnPush + `ViewEncapsulation.None`, signal inputs, utility-first on the AMRIT theme tokens (no hex), and follow the existing v2/ui conventions (cva `*.variants.ts`, `index.ts` barrel, GPL header, `mergeClasses`).

| Component | Selectors | Notes |
|---|---|---|
| **radio-group** | `z-radio-group` + extended `z-radio` | Group is the `ControlValueAccessor` and owns the value; `z-radio` reflects/updates an optional parent group. **Standalone `z-radio` behaviour is unchanged** (backward compatible). |
| **accordion** | `z-accordion`, `z-accordion-item`, `z-accordion-trigger`, `z-accordion-content` | `single`/`multiple`, collapsible, chevron rotate, grid-rows open/close animation. |
| **combobox** | `z-combobox` | Type-to-filter autocomplete (CVA) over a finite option list (`string[]` or objects via `zLabelKey`/`zValueKey`); keyboard nav + click-outside + a11y. |
| **toggle-group** | `z-toggle-group`, `z-toggle-group-item` | Segmented control (CVA), `single`/`multiple`. |
| **badge** | `z-badge` | `zType` variants (default/secondary/destructive/outline/success/warning). |
| **stepper** | `z-stepper`, `z-step` | Horizontal step indicator (completed/active/upcoming + connectors). |
| **sheet** | `z-sheet` | Slide-over drawer (left/right/top/bottom), two-way `zOpen`. |

## Why

A survey of the un-migrated MMU screens found these are the only missing Zard primitives blocking ~60 of the ~110 remaining screens — **radio-group (33 screens)** and **accordion (24 screens)** are the biggest unblockers; combobox covers the service-point autocomplete; the rest are niche (1–3 screens each).

## Verification

Compiled against MMU via a temporary harness that imports and uses all seven (reactive-form bindings, content projection, two-way `model`) — **AOT build green**, then the harness was removed. No existing component changed except the additive `z-radio` group-awareness (standalone unchanged).

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new UI building blocks: accordion, badge, combobox, radio group, sheet, stepper, and toggle group.
  * Introduced support for grouped and standalone radio behavior, selectable accordions, searchable comboboxes, slide-over sheets, multi-step progress, and segmented toggles.
  * Added visual variants and shared import entry points for easier use across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->