### PR TITLE
fix(ui): z-select label display, z-radio indicator + consent button

### DIFF
--- a/src/registrar/registration/consent-form/consent-form.component.html
+++ b/src/registrar/registration/consent-form/consent-form.component.html
@@ -28,7 +28,7 @@
       class="full-width-login mat_blue"
       type="button"
       (click)="acceptConsent('1')">
-      {{ currentLanguageSet?.tc?.accept || 'Accept' }}
+      {{ currentLanguageSet?.tc?.accept }}
     </button>
   </mat-dialog-actions>
 </section>

--- a/src/registrar/registration/consent-form/consent-form.component.html
+++ b/src/registrar/registration/consent-form/consent-form.component.html
@@ -28,7 +28,7 @@
       class="full-width-login mat_blue"
       type="button"
       (click)="acceptConsent('1')">
-      {{ currentLanguageSet?.tc?.accept }}
+      {{ currentLanguageSet?.tc?.accept || 'Accept' }}
     </button>
   </mat-dialog-actions>
 </section>

--- a/v2/registrar/registration/consent-form/consent-form.component.html
+++ b/v2/registrar/registration/consent-form/consent-form.component.html
@@ -28,7 +28,7 @@
       class="full-width-login mat_blue"
       type="button"
       (click)="acceptConsent('1')">
-      {{ currentLanguageSet?.tc?.accept }}
+      {{ currentLanguageSet?.tc?.accept || 'Accept' }}
     </button>
   </mat-dialog-actions>
 </section>

--- a/v2/ui/radio/radio.component.ts
+++ b/v2/ui/radio/radio.component.ts
@@ -67,7 +67,8 @@ type OnChangeType = (value: unknown) => void;
         [name]="resolvedName()"
         [id]="zId() || z.id()" />
       <span
-        class="bg-primary pointer-events-none absolute left-1 size-2 rounded-full opacity-0 peer-checked:opacity-100"></span>
+        class="bg-primary pointer-events-none absolute left-1 top-1/2 size-2 -translate-y-1/2 rounded-full opacity-0 transition-opacity"
+        [class.opacity-100]="isChecked()"></span>
       <label [class]="labelClasses()" [for]="zId() || z.id()">
         <ng-content />
       </label>

--- a/v2/ui/select/select.component.ts
+++ b/v2/ui/select/select.component.ts
@@ -651,7 +651,13 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
     // string-vs-number mismatch and the trigger shows the raw id instead of
     // the option label.
     if (this.zMultiple() && Array.isArray(value)) {
-      this.zValue.set(value.map(v => String(v)));
+      this.zValue.set(value.map(String));
+    } else if (this.zMultiple()) {
+      // Multi-select must stay array-backed: a nullish/non-array write (e.g.
+      // a form reset) would otherwise store '' and break the Array.isArray
+      // branch in selectItem()/selectedLabels(), so the next pick stops
+      // accumulating. Reset to an empty array instead.
+      this.zValue.set([]);
     } else {
       this.zValue.set(value === null || value === undefined ? '' : String(value));
     }

--- a/v2/ui/select/select.component.ts
+++ b/v2/ui/select/select.component.ts
@@ -644,10 +644,16 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
 
   // ControlValueAccessor implementation
   writeValue(value: string | string[] | null): void {
+    // The select is string-valued by contract (its items carry string values
+    // and onChange emits a string). A form may legitimately hold a number
+    // (e.g. a numeric id), so normalize any incoming value to string here —
+    // otherwise label matching (item.zValue() === value) fails on a
+    // string-vs-number mismatch and the trigger shows the raw id instead of
+    // the option label.
     if (this.zMultiple() && Array.isArray(value)) {
-      this.zValue.set(value);
+      this.zValue.set(value.map(v => String(v)));
     } else {
-      this.zValue.set(value ?? '');
+      this.zValue.set(value === null || value === undefined ? '' : String(value));
     }
   }
 


### PR DESCRIPTION
## What
Bug fixes surfaced while migrating the MMU service-point and registrar screens.

### `z-select` — show the option label, not the raw value
`writeValue` now normalizes the incoming value to a string. The select is string-valued by contract (items carry string values, `onChange` emits a string), but a reactive form may legitimately hold a number (e.g. a numeric id). Previously the label lookup `item.zValue() === value` failed on a string-vs-number mismatch and the trigger displayed the raw id instead of the option label.

### `z-radio` — show the selected fill reliably
The indicator dot is now driven by the component's own `isChecked()` state (shadcn's `data-state` approach) and centered over the control, instead of relying on the native `peer-checked` pseudo on a property-bound radio (which didn't fire reliably for grouped radios).

### registrar consent — fallback button label
The `tc.accept` i18n key is absent in the language files, so the beneficiary-consent dialog button rendered with an empty label and collapsed to a sliver. Falls back to `'Accept'`.

## Testing
Verified live against the MMU service-point screen (dropdowns show names; radio fills) and the registration consent dialog (button visible/clickable). Full AOT build green.

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The consent form’s primary action now shows a clear default label when no translation is available.

* **Bug Fixes**
  * Improved radio selection visibility so the selected state displays more reliably.
  * Fixed select inputs to handle form values consistently, including numeric and other non-text values, improving matching and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->