### PR TITLE
fix(ui): reset list styling on z-pagination content

### DIFF
--- a/v2/ui/pagination/pagination.variants.ts
+++ b/v2/ui/pagination/pagination.variants.ts
@@ -22,7 +22,7 @@
 
 import { cva, type VariantProps } from 'class-variance-authority';
 
-export const paginationContentVariants = cva('flex flex-row items-center gap-1');
+export const paginationContentVariants = cva('flex list-none flex-row items-center gap-1 p-0');
 export type ZardPaginationContentVariants = VariantProps<typeof paginationContentVariants>;
 
 export const paginationPreviousVariants = cva('gap-1 px-2.5 sm:pl-2.5');


### PR DESCRIPTION
## What
The pagination `<ul>` (`paginationContentVariants`) was `flex flex-row items-center gap-1` with no `list-none`. It relied on Tailwind preflight to strip the default list markers/indentation — but the host app (MMU) runs with **preflight off**, so stray bullet dots and left indentation leaked into every paginated screen (visible on the worklists).

Add `list-none p-0` so the component is self-contained regardless of preflight.

## Testing
Visual: the `•` dots between pagination controls are gone. No behavior change.

@coderabbitai review