### PR TITLE
feat(ui): add z-paginator (smart client-side paginator)

### DIFF
--- a/v2/ui/paginator/index.ts
+++ b/v2/ui/paginator/index.ts
@@ -1,0 +1,23 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+export * from './paginator.component';

--- a/v2/ui/paginator/paginator.component.ts
+++ b/v2/ui/paginator/paginator.component.ts
@@ -1,0 +1,140 @@
+/*
+ * AMRIT – Accessible Medical Records via Integrated Technologies
+ * Integrated EHR (Electronic Health Records) Solution
+ *
+ * Copyright (C) "Piramal Swasthya Management and Research Institute"
+ *
+ * This file is part of AMRIT.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see https://www.gnu.org/licenses/.
+ */
+
+import {
+  booleanAttribute,
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  input,
+  linkedSignal,
+  output,
+  signal,
+  ViewEncapsulation,
+} from '@angular/core';
+import type { ClassValue } from 'clsx';
+
+import { ZardPaginationComponent } from '../pagination';
+import { ZardSelectImports } from '../select';
+import { mergeClasses } from '../utils/merge-classes';
+
+/**
+ * A "smart" client-side paginator that composes the presentational `z-pagination`
+ * primitive with a rows-per-page selector, and owns the page/size state + slicing.
+ *
+ * It removes the boilerplate each table screen used to hand-roll
+ * (`totalPages`/`pagedList`/`goToPage`/`prevPage`/`nextPage`/`changePageSize`).
+ *
+ * Usage — the parent still renders its own table rows from the emitted slice:
+ *   <z-paginator [zData]="filteredList" (zPagedChange)="pagedItems = $event"></z-paginator>
+ *   <!-- or read it directly: <z-paginator #p [zData]="list"/> ... *ngFor="let x of p.pagedItems()" -->
+ */
+@Component({
+  selector: 'z-paginator, [z-paginator]',
+  imports: [ZardPaginationComponent, ...ZardSelectImports],
+  template: `
+    @if (totalItems() > 0) {
+      <div class="flex flex-wrap items-center justify-end gap-4">
+        @if (zShowPageSize()) {
+          <div
+            class="inline-flex items-center gap-2 text-[0.8125rem] text-muted-foreground">
+            <span>{{ zRowsPerPageLabel() }}</span>
+            <z-select
+              class="w-[4.5rem]"
+              name="pageSize"
+              [zValue]="pageSize().toString()"
+              (zSelectionChange)="onPageSizeChange($event)">
+              @for (size of zPageSizeOptions(); track size) {
+                <z-select-item [zValue]="size.toString()">{{ size }}</z-select-item>
+              }
+            </z-select>
+          </div>
+        }
+        <z-pagination
+          [zPageIndex]="currentPage()"
+          [zTotal]="totalPages()"
+          (zPageIndexChange)="currentPage.set($event)"></z-pagination>
+      </div>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    'data-slot': 'paginator',
+    '[class]': 'classes()',
+  },
+  exportAs: 'zPaginator',
+})
+export class ZardPaginatorComponent {
+  /** The full list to paginate. */
+  readonly zData = input<readonly unknown[] | null | undefined>([]);
+  /** Rows-per-page choices; the first is the initial page size. */
+  readonly zPageSizeOptions = input<number[]>([5, 10, 20]);
+  /** Whether to show the rows-per-page selector. */
+  readonly zShowPageSize = input(true, { transform: booleanAttribute });
+  /** Label shown before the rows-per-page selector. */
+  readonly zRowsPerPageLabel = input('Rows per page');
+  readonly class = input<ClassValue>('');
+
+  /** Emits the current page's slice whenever page/size/data changes. */
+  readonly zPagedChange = output<unknown[]>();
+
+  /** Page size — defaults to (and re-syncs with) the first option. */
+  readonly pageSize = linkedSignal(() => this.zPageSizeOptions()[0] ?? 5);
+  readonly currentPage = signal(1);
+
+  readonly totalItems = computed(() => (this.zData() ?? []).length);
+  readonly totalPages = computed(() =>
+    Math.max(1, Math.ceil(this.totalItems() / this.pageSize()))
+  );
+  readonly pagedItems = computed<unknown[]>(() => {
+    const items = this.zData() ?? [];
+    const size = this.pageSize();
+    const page = Math.min(this.currentPage(), this.totalPages());
+    const start = (page - 1) * size;
+    return items.slice(start, start + size);
+  });
+
+  protected readonly classes = computed(() =>
+    mergeClasses('block w-full', this.class())
+  );
+
+  constructor() {
+    // Reset to the first page whenever the underlying list changes (e.g. a new search).
+    effect(
+      () => {
+        this.zData();
+        this.currentPage.set(1);
+      },
+      { allowSignalWrites: true }
+    );
+    // Publish the current page's slice to consumers that bind (zPagedChange).
+    effect(() => this.zPagedChange.emit(this.pagedItems()));
+  }
+
+  protected onPageSizeChange(value: string | string[]): void {
+    const next = Array.isArray(value) ? value[0] : value;
+    this.pageSize.set(Number(next));
+    this.currentPage.set(1);
+  }
+}

--- a/v2/ui/select/select.component.ts
+++ b/v2/ui/select/select.component.ts
@@ -65,7 +65,7 @@ import {
 import { mergeClasses } from '../utils/merge-classes';
 
 type OnTouchedType = () => void;
-type OnChangeType = (value: string) => void;
+type OnChangeType = (value: string | string[]) => void;
 
 const COMPACT_MODE_WIDTH_THRESHOLD = 100;
 
@@ -183,7 +183,7 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
     return this.provideLabelForSingleSelectMode(selectedValue as string);
   });
 
-  private onChange: OnChangeType = (_value: string) => {
+  private onChange: OnChangeType = (_value: string | string[]) => {
     // ControlValueAccessor onChange callback
   };
 
@@ -305,7 +305,9 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
 
       return value;
     });
-    this.onChange(value);
+    // In multiple mode the reactive control must receive the accumulated array
+    // (zValue after the update), not just the single clicked value.
+    this.onChange(this.zValue());
     this.zSelectionChange.emit(this.zValue());
 
     if (this.zMultiple()) {
@@ -663,7 +665,7 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
     }
   }
 
-  registerOnChange(fn: (value: string) => void): void {
+  registerOnChange(fn: (value: string | string[]) => void): void {
     this.onChange = fn;
   }
 


### PR DESCRIPTION
## What
Add a shared **`z-paginator`** — a "smart" client-side paginator that composes the existing presentational `z-pagination` primitive with a rows-per-page selector, and owns the page/size state + slicing.

## Why
Every migrated table screen (calibration, previous-details, provisional-search, allergen-search, worklists…) was hand-rolling the *identical* pagination logic (`totalPages` / `pagedList` / `pageNumbers` / `goToPage` / `prevPage` / `nextPage` / `changePageSize`) and the identical rows-per-page + prev/next markup — because `z-pagination` is presentation-only and doesn't slice data. That duplication tripped SonarCloud (17.5% on the core-dialogs PR). This encapsulates it once.

## API
```html
<!-- parent still renders its own table rows from the emitted slice -->
<z-paginator [zData]="filteredList" (zPagedChange)="pagedItems = $event"></z-paginator>
<!-- or read directly: <z-paginator #p [zData]="list"/> ... *ngFor="let x of p.pagedItems()" -->
```
- `[zData]` — the full list to paginate
- `[zPageSizeOptions]` (default `[5,10,20]`) — first is the initial size
- `[zShowPageSize]` (default `true`) — toggle the rows-per-page selector
- `[zRowsPerPageLabel]` (default `'Rows per page'`)
- `(zPagedChange)` — emits the current page's slice on any page/size/data change; also exposed as the public `pagedItems()` signal
- Self-hides when the list is empty; resets to page 1 when `zData` changes.

Built on signals (`linkedSignal`/`computed`/`effect`), standalone, OnPush, theme-tokens only. Consumers (the 4 core dialogs) are rewired in the MMU-UI PR.



@coderabbitai review
