### PR TITLE
feat(ui): add afterClosed() + caller-injector resolution to Zard dialog service

### DIFF
--- a/v2/ui/dialog/dialog-ref.ts
+++ b/v2/ui/dialog/dialog-ref.ts
@@ -24,7 +24,7 @@ import type { OverlayRef } from '@angular/cdk/overlay';
 import { isPlatformBrowser } from '@angular/common';
 import { EventEmitter, Inject, PLATFORM_ID } from '@angular/core';
 
-import { filter, fromEvent, Subject, takeUntil } from 'rxjs';
+import { filter, fromEvent, Observable, Subject, takeUntil } from 'rxjs';
 
 import type { ZardDialogComponent, ZardDialogOptions } from './dialog.component';
 
@@ -35,6 +35,7 @@ const enum eTriggerAction {
 
 export class ZardDialogRef<T = any, R = any, U = any> {
   private destroy$ = new Subject<void>();
+  private readonly afterClosed$ = new Subject<R | undefined>();
   private isClosing = false;
   protected result?: R;
   componentInstance: T | null = null;
@@ -90,7 +91,19 @@ export class ZardDialogRef<T = any, R = any, U = any> {
         this.destroy$.next();
         this.destroy$.complete();
       }
+
+      this.afterClosed$.next(this.result);
+      this.afterClosed$.complete();
     }, 150);
+  }
+
+  /**
+   * Emits the close result once, after the dialog has closed, then completes.
+   * Mirrors MatDialogRef.afterClosed() so callers migrating off Material keep
+   * the `create(...).afterClosed().subscribe(result => ...)` pattern unchanged.
+   */
+  afterClosed(): Observable<R | undefined> {
+    return this.afterClosed$.asObservable();
   }
 
   private trigger(action: eTriggerAction) {

--- a/v2/ui/dialog/dialog.service.ts
+++ b/v2/ui/dialog/dialog.service.ts
@@ -135,8 +135,12 @@ export class ZardDialogService {
   }
 
   private createInjector<T, U>(dialogRef: ZardDialogRef<T>, config: ZardDialogOptions<T, U>) {
+    // Resolve the content component against the caller's injector when a
+    // ViewContainerRef is supplied, so route/feature-scoped providers (not just
+    // root) are available inside the dialog. Falls back to the service's root
+    // injector. Mirrors MatDialog's viewContainerRef behaviour.
     return Injector.create({
-      parent: this.injector,
+      parent: config.zViewContainerRef?.injector ?? this.injector,
       providers: [
         { provide: ZardDialogRef, useValue: dialogRef },
         { provide: Z_MODAL_DATA, useValue: config.zData },


### PR DESCRIPTION
## What
Two additive enhancements so the Zard dialog system can fully replace Angular Material's `MatDialog`:

1. **`ZardDialogRef.afterClosed()`** — returns an Observable that emits the close result once (after the close animation) and completes. Mirrors `MatDialogRef.afterClosed()`.
2. **Caller-injector resolution in `ZardDialogService`** — the content component is created against the caller's `ViewContainerRef` injector when passed via `zViewContainerRef` (falls back to the root injector), so route/feature-scoped providers resolve inside dialogs.

## Why
Preparatory step for migrating the apps' `MatDialog` usages to `ZardDialogService`. Both changes preserve existing behaviour:
- `afterClosed()` lets callers keep the `create(...).afterClosed().subscribe(result => ...)` pattern verbatim.
- Injector resolution prevents `NG0201: No provider found` when a dialog injects a route-scoped service.

## Notes
- Purely additive — no existing API changed.
- Uses the already-present `@angular/cdk` overlay/portal; no new dependencies.
- Stacked on `feat/paginator` (#71); retarget to `angular-zard-migration` once that merges.
