### PR TITLE
refactor(ui): migrate registrar dialogs to ZardDialogService (off MatDialog)

### DIFF
--- a/v2/registrar/abha-components/abha-consent-form/abha-consent-form.component.ts
+++ b/v2/registrar/abha-components/abha-consent-form/abha-consent-form.component.ts
@@ -22,7 +22,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormControl, ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX } from '@ng-icons/lucide';
 import { SessionStorageService } from '../../services/session-storage.service';
@@ -56,7 +56,7 @@ export class AbhaConsentFormComponent {
   userName = this.sessionstorage.getItem('userName');
 
   constructor(
-    public dialogRef: MatDialogRef<AbhaConsentFormComponent>,
+    public dialogRef: ZardDialogRef<AbhaConsentFormComponent>,
     private sessionstorage: SessionStorageService,
   ) {}
 

--- a/v2/registrar/abha-components/abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component.ts
+++ b/v2/registrar/abha-components/abha-enter-mobile-otp-component/abha-enter-mobile-otp-component.component.ts
@@ -5,7 +5,7 @@ import {
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
@@ -43,8 +43,8 @@ export class AbhaEnterMobileOtpComponentComponent {
 
   constructor(
     private fb: FormBuilder,
-    public dialogSucRef: MatDialogRef<AbhaEnterMobileOtpComponentComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogSucRef: ZardDialogRef<AbhaEnterMobileOtpComponentComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
     public httpServiceService: HttpServiceService,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService,

--- a/v2/registrar/abha-components/abha-enter-otp-component/abha-enter-otp-component.component.ts
+++ b/v2/registrar/abha-components/abha-enter-otp-component/abha-enter-otp-component.component.ts
@@ -57,8 +57,8 @@ export class AbhaEnterOtpComponentComponent {
     @Inject(Z_MODAL_DATA) public data: any,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
   ) {
     dialogRef.disableClose = true;
   }

--- a/v2/registrar/abha-components/abha-enter-otp-component/abha-enter-otp-component.component.ts
+++ b/v2/registrar/abha-components/abha-enter-otp-component/abha-enter-otp-component.component.ts
@@ -1,11 +1,11 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, ViewContainerRef } from '@angular/core';
 import {
   FormGroup,
   FormBuilder,
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA, ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
@@ -52,12 +52,13 @@ export class AbhaEnterOtpComponentComponent {
 
   constructor(
     private fb: FormBuilder,
-    public dialogRef: MatDialogRef<AbhaEnterOtpComponentComponent>,
+    public dialogRef: ZardDialogRef<AbhaEnterOtpComponentComponent>,
     public httpServiceService: HttpServiceService,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(Z_MODAL_DATA) public data: any,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
   ) {
     dialogRef.disableClose = true;
   }
@@ -137,15 +138,15 @@ export class AbhaEnterOtpComponentComponent {
   }
 
   askMobileNumberForAbha() {
-    const dialogRefMobile = this.dialog.open(
-      AbhaMobileComponentComponent,
-      {
-        height: '250px',
-        width: '420px',
-        disableClose: true,
-        data: { txnId: this.transactionId, otp: this.healthIdOTPForm.controls['otp'].value, },
-      },
-    );
+    const dialogRefMobile = this.dialog.create({
+      zContent: AbhaMobileComponentComponent,
+      zData: { txnId: this.transactionId, otp: this.healthIdOTPForm.controls['otp'].value, },
+      zWidth: '420px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
+    });
     this.showProgressBar = false;
     dialogRefMobile.afterClosed().subscribe((response) => {
       if (response) {
@@ -160,15 +161,15 @@ export class AbhaEnterOtpComponentComponent {
 
   displayAbhaNumberOnSuccess(data: any) {
     console.log("Abha profile response - ", data);
-    const dialogRefSuccess = this.dialog.open(
-      AbhaGenerationSuccessComponentComponent,
-      {
-        height: '365px',
-        width: '480px',
-        disableClose: true,
-        data: { newAbhaResponse: data, xToken: data.xToken, mobileNumber: this.mobileNumber }
-      },
-    );
+    const dialogRefSuccess = this.dialog.create({
+      zContent: AbhaGenerationSuccessComponentComponent,
+      zData: { newAbhaResponse: data, xToken: data.xToken, mobileNumber: this.mobileNumber },
+      zWidth: '480px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
+    });
     this.showProgressBar = false;
     dialogRefSuccess.afterClosed().subscribe((result) => {
       let abhaData = data.ABHAProfile;
@@ -281,15 +282,15 @@ export class AbhaEnterOtpComponentComponent {
 
   displayAbhaNumberOnVerify(abhaDetails: any, token: any) {
     console.log("Abha details response - ", abhaDetails);
-    const dialogRefSuccess = this.dialog.open(
-      AbhaVerifySuccessComponentComponent,
-      {
-        height: '370px',
-        width: '480px',
-        disableClose: true,
-        data: { abhaResponse: abhaDetails, xToken: token, loginHint: this.loginHint }
-      },
-    );
+    const dialogRefSuccess = this.dialog.create({
+      zContent: AbhaVerifySuccessComponentComponent,
+      zData: { abhaResponse: abhaDetails, xToken: token, loginHint: this.loginHint },
+      zWidth: '480px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
+    });
     this.showProgressBar = false;
     dialogRefSuccess.afterClosed().subscribe((result) => {
       if (result) {

--- a/v2/registrar/abha-components/abha-generation-success-component/abha-generation-success-component.component.ts
+++ b/v2/registrar/abha-components/abha-generation-success-component/abha-generation-success-component.component.ts
@@ -55,8 +55,8 @@ export class AbhaGenerationSuccessComponentComponent {
   constructor(
     public dialogSucRef: ZardDialogRef<AbhaGenerationSuccessComponentComponent>,
     @Inject(Z_MODAL_DATA) public data: any,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     public httpServiceService: HttpServiceService,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService
@@ -103,7 +103,7 @@ export class AbhaGenerationSuccessComponentComponent {
 
   GivePageToMobileEnterOtp(){
     this.dialogSucRef.close();
-    let dialogRef = this.dialog.create({
+    this.dialog.create({
       zContent: AbhaEnterMobileOtpComponentComponent,
       zData: {txnId: this.txnId, mobileNumber: this.mobileNumber },
       zWidth: '420px',
@@ -148,7 +148,7 @@ export class AbhaGenerationSuccessComponentComponent {
   }
 
   displayAbhaCard(png: any){
-    let matDialogRef = this.dialog.create({
+    this.dialog.create({
       zContent: DisplayAbhaCardComponent,
       zData: {png: png},
       zWidth: "auto",

--- a/v2/registrar/abha-components/abha-generation-success-component/abha-generation-success-component.component.ts
+++ b/v2/registrar/abha-components/abha-generation-success-component/abha-generation-success-component.component.ts
@@ -20,8 +20,8 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject, ViewContainerRef } from '@angular/core';
+import { ZardDialogRef, Z_MODAL_DATA, ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideCircleCheck, lucideX } from '@ng-icons/lucide';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
@@ -53,9 +53,10 @@ export class AbhaGenerationSuccessComponentComponent {
   mobileNumber: any;
 
   constructor(
-    public dialogSucRef: MatDialogRef<AbhaGenerationSuccessComponentComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
-    private dialog: MatDialog,
+    public dialogSucRef: ZardDialogRef<AbhaGenerationSuccessComponentComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     public httpServiceService: HttpServiceService,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService
@@ -102,10 +103,13 @@ export class AbhaGenerationSuccessComponentComponent {
 
   GivePageToMobileEnterOtp(){
     this.dialogSucRef.close();
-    let dialogRef = this.dialog.open(AbhaEnterMobileOtpComponentComponent, {
-      height: '250px',
-      width: '420px',
-      data: {txnId: this.txnId, mobileNumber: this.mobileNumber }
+    let dialogRef = this.dialog.create({
+      zContent: AbhaEnterMobileOtpComponentComponent,
+      zData: {txnId: this.txnId, mobileNumber: this.mobileNumber },
+      zWidth: '420px',
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
     // dialogRef.close();
   }
@@ -144,11 +148,14 @@ export class AbhaGenerationSuccessComponentComponent {
   }
 
   displayAbhaCard(png: any){
-    let matDialogRef = this.dialog.open(DisplayAbhaCardComponent, {
-      height: "auto",
-      width: "auto",
-      disableClose: true,
-      data: {png: png}
+    let matDialogRef = this.dialog.create({
+      zContent: DisplayAbhaCardComponent,
+      zData: {png: png},
+      zWidth: "auto",
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
   }
 }

--- a/v2/registrar/abha-components/abha-mobile-component/abha-mobile-component.component.ts
+++ b/v2/registrar/abha-components/abha-mobile-component/abha-mobile-component.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
@@ -40,8 +40,8 @@ export class AbhaMobileComponentComponent {
 
   constructor(
     private fb: FormBuilder,
-    public dialogSucRef: MatDialogRef<AbhaMobileComponentComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogSucRef: ZardDialogRef<AbhaMobileComponentComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
     public httpServiceService: HttpServiceService,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService,

--- a/v2/registrar/abha-components/abha-verify-success-component/abha-verify-success-component.component.ts
+++ b/v2/registrar/abha-components/abha-verify-success-component/abha-verify-success-component.component.ts
@@ -20,8 +20,8 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Component, Inject, ViewContainerRef } from '@angular/core';
+import { ZardDialogRef, Z_MODAL_DATA, ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideCircleCheck, lucideX } from '@ng-icons/lucide';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
@@ -47,9 +47,10 @@ export class AbhaVerifySuccessComponentComponent {
   showProgressBar = false;
 
   constructor(
-    public dialogSucRef: MatDialogRef<AbhaVerifySuccessComponentComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
-    private dialog: MatDialog,
+    public dialogSucRef: ZardDialogRef<AbhaVerifySuccessComponentComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     public httpServiceService: HttpServiceService,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService
@@ -100,10 +101,13 @@ export class AbhaVerifySuccessComponentComponent {
   }
 
   displayAbhaCard(png: any) {
-    let matDialogRef = this.dialog.open(DisplayAbhaCardComponent, {
-      height: 'auto',
-      width: 'auto',
-      data: { png: png }
+    let matDialogRef = this.dialog.create({
+      zContent: DisplayAbhaCardComponent,
+      zData: { png: png },
+      zWidth: 'auto',
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
   }
 

--- a/v2/registrar/abha-components/abha-verify-success-component/abha-verify-success-component.component.ts
+++ b/v2/registrar/abha-components/abha-verify-success-component/abha-verify-success-component.component.ts
@@ -49,8 +49,8 @@ export class AbhaVerifySuccessComponentComponent {
   constructor(
     public dialogSucRef: ZardDialogRef<AbhaVerifySuccessComponentComponent>,
     @Inject(Z_MODAL_DATA) public data: any,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     public httpServiceService: HttpServiceService,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService
@@ -101,7 +101,7 @@ export class AbhaVerifySuccessComponentComponent {
   }
 
   displayAbhaCard(png: any) {
-    let matDialogRef = this.dialog.create({
+    this.dialog.create({
       zContent: DisplayAbhaCardComponent,
       zData: { png: png },
       zWidth: 'auto',

--- a/v2/registrar/abha-components/biometric-authentication/biometric-authentication.component.ts
+++ b/v2/registrar/abha-components/biometric-authentication/biometric-authentication.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, Inject, OnInit } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { RegistrarService } from '../../services/registrar.service';
 import { RdDeviceService } from '../../services/rddevice.service';
@@ -50,13 +50,12 @@ export class BiometricAuthenticationComponent implements OnInit {
   currentLanguageSet: any;
 
   constructor(
-    public matDialogRef: MatDialogRef<BiometricAuthenticationComponent>,
+    public matDialogRef: ZardDialogRef<BiometricAuthenticationComponent>,
     private rddeviceService: RdDeviceService,
     private registrarService: RegistrarService,
-    private dialog: MatDialog,
     private confirmationService: ConfirmationService,
     public httpServiceService: HttpServiceService,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(Z_MODAL_DATA) public data: any,
   ) {}
 
   ngOnInit() {

--- a/v2/registrar/abha-components/display-abha-card/display-abha-card.component.ts
+++ b/v2/registrar/abha-components/display-abha-card/display-abha-card.component.ts
@@ -21,7 +21,7 @@
  */
 
 import { Component, Inject } from '@angular/core';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { DomSanitizer } from '@angular/platform-browser';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX } from '@ng-icons/lucide';
@@ -48,10 +48,9 @@ export class DisplayAbhaCardComponent {
   currentLanguageSet: any;
 
   constructor(
-    public dialogRef: MatDialogRef<DisplayAbhaCardComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public dialogRef: ZardDialogRef<DisplayAbhaCardComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
     public httpServiceService: HttpServiceService,
-    private dialog: MatDialog,
     public sanitizer: DomSanitizer,
     private confirmationService: ConfirmationService,
   ) {

--- a/v2/registrar/abha-components/download-search-abha/download-search-abha.component.ts
+++ b/v2/registrar/abha-components/download-search-abha/download-search-abha.component.ts
@@ -19,9 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, ViewContainerRef } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA, ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
@@ -70,9 +70,10 @@ export class DownloadSearchAbhaComponent {
   allowAuthIdCharacters: number = 0;
 
   constructor(
-    public dialogRef: MatDialogRef<DownloadSearchAbhaComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
-    private dialog: MatDialog,
+    public dialogRef: ZardDialogRef<DownloadSearchAbhaComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     private fb: FormBuilder,
     public httpServiceService: HttpServiceService,
     private registrarService: RegistrarService,
@@ -253,15 +254,18 @@ export class DownloadSearchAbhaComponent {
     } else if (loginHint === "abha-address" && loginMethod === "mobile") {
       loginMethod = "abha-mobile"
     }
-    const dialogRef = this.dialog.open(AbhaEnterOtpComponentComponent, {
-      height: '250px',
-      width: '420px',
-      data: {
+    const dialogRef = this.dialog.create({
+      zContent: AbhaEnterOtpComponentComponent,
+      zData: {
         txnId: txnId,
         loginMethod: loginMethod,
         loginHint: loginHint,
         aadharNumber: (this.abhaAuthMethodForm.controls['abhaAuthId'].value) ? this.abhaAuthMethodForm.controls['abhaAuthId'].value : (this.adhaarNumberForm.controls['part1'].value + this.adhaarNumberForm.controls['part2'].value + this.adhaarNumberForm.controls['part3'].value)
       },
+      zWidth: '420px',
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
     this.dialogRef.afterClosed();
   }

--- a/v2/registrar/abha-components/download-search-abha/download-search-abha.component.ts
+++ b/v2/registrar/abha-components/download-search-abha/download-search-abha.component.ts
@@ -72,8 +72,8 @@ export class DownloadSearchAbhaComponent {
   constructor(
     public dialogRef: ZardDialogRef<DownloadSearchAbhaComponent>,
     @Inject(Z_MODAL_DATA) public data: any,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     private fb: FormBuilder,
     public httpServiceService: HttpServiceService,
     private registrarService: RegistrarService,
@@ -254,7 +254,7 @@ export class DownloadSearchAbhaComponent {
     } else if (loginHint === "abha-address" && loginMethod === "mobile") {
       loginMethod = "abha-mobile"
     }
-    const dialogRef = this.dialog.create({
+    this.dialog.create({
       zContent: AbhaEnterOtpComponentComponent,
       zData: {
         txnId: txnId,

--- a/v2/registrar/abha-components/generate-abha-component/generate-abha-component.component.ts
+++ b/v2/registrar/abha-components/generate-abha-component/generate-abha-component.component.ts
@@ -67,8 +67,8 @@ export class GenerateAbhaComponentComponent {
     public dialogRef: ZardDialogRef<GenerateAbhaComponentComponent>,
     public httpServiceService: HttpServiceService,
     private fb: FormBuilder,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService,
   ) {}
@@ -133,7 +133,7 @@ export class GenerateAbhaComponentComponent {
   }
 
   routeToOtpPage(txnId: any) {
-    const dialogRef = this.dialog.create({
+    this.dialog.create({
       zContent: AbhaEnterOtpComponentComponent,
       zData: {
         txnId: txnId,

--- a/v2/registrar/abha-components/generate-abha-component/generate-abha-component.component.ts
+++ b/v2/registrar/abha-components/generate-abha-component/generate-abha-component.component.ts
@@ -19,9 +19,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { Component } from '@angular/core';
+import { Component, ViewContainerRef } from '@angular/core';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef, ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import { RegistrarService } from '../../services/registrar.service';
@@ -64,10 +64,11 @@ export class GenerateAbhaComponentComponent {
   maskedAadharNumber: string = '';
 
   constructor(
-    public dialogRef: MatDialogRef<GenerateAbhaComponentComponent>,
+    public dialogRef: ZardDialogRef<GenerateAbhaComponentComponent>,
     public httpServiceService: HttpServiceService,
     private fb: FormBuilder,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService,
   ) {}
@@ -132,25 +133,30 @@ export class GenerateAbhaComponentComponent {
   }
 
   routeToOtpPage(txnId: any) {
-    const dialogRef = this.dialog.open(AbhaEnterOtpComponentComponent, {
-      height: '250px',
-      width: '420px',
-      data: {
+    const dialogRef = this.dialog.create({
+      zContent: AbhaEnterOtpComponentComponent,
+      zData: {
         txnId: txnId,
         healthIdMode: this.modeofAbhaHealthID,
         aadharNumber: this.aadharNumber
       },
+      zWidth: '420px',
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
   }
 
   captureBioAuthentication() {
-    const matDialogRef: MatDialogRef<BiometricAuthenticationComponent> =
-      this.dialog.open(BiometricAuthenticationComponent, {
-        width: '500px',
-        height: '320px',
-        disableClose: true,
-        data: { aadharNumber: this.aadharNumber }
-      });
+    const matDialogRef = this.dialog.create<BiometricAuthenticationComponent, unknown>({
+      zContent: BiometricAuthenticationComponent,
+      zData: { aadharNumber: this.aadharNumber },
+      zWidth: '500px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
+    });
     matDialogRef.afterClosed().subscribe((res) => {
       console.log("mat dialog close response: ", res)
       if(res){
@@ -160,14 +166,17 @@ export class GenerateAbhaComponentComponent {
   }
 
   mobileNumberCapturePage(pid: any) {
-    const dialogRef = this.dialog.open(AbhaMobileComponentComponent, {
-      height: '250px',
-      width: '420px',
-      data: {
+    const dialogRef = this.dialog.create({
+      zContent: AbhaMobileComponentComponent,
+      zData: {
         healthIdMode: this.modeofAbhaHealthID,
         pId: pid,
         aadharNumber: this.aadharNumber
       },
+      zWidth: '420px',
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
     dialogRef.afterClosed().subscribe((result) => {
     });

--- a/v2/registrar/abha-components/health-id-display-modal/health-id-display-modal.component.ts
+++ b/v2/registrar/abha-components/health-id-display-modal/health-id-display-modal.component.ts
@@ -105,8 +105,8 @@ export class HealthIdDisplayModalComponent implements OnInit, DoCheck {
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService,
     private datePipe: DatePipe,
-    private dialogMd: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialogMd: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     private readonly sessionstorage: SessionStorageService
   ) {
     dialogRef.disableClose = true;
@@ -311,7 +311,7 @@ export class HealthIdDisplayModalComponent implements OnInit, DoCheck {
   }
 
   printHealthIDCard(data: any) {
-    const dialogRefValue = this.dialogMd.create({
+    this.dialogMd.create({
       zContent: DownloadSearchAbhaComponent,
       zData: {
         printCard: true,

--- a/v2/registrar/abha-components/health-id-display-modal/health-id-display-modal.component.ts
+++ b/v2/registrar/abha-components/health-id-display-modal/health-id-display-modal.component.ts
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { Component, DoCheck, Inject, OnInit } from '@angular/core';
+import { Component, DoCheck, Inject, OnInit, ViewContainerRef } from '@angular/core';
 import {
   FormGroup,
   FormBuilder,
@@ -28,10 +28,10 @@ import {
 } from '@angular/forms';
 import { DatePipe, NgIf, NgFor } from '@angular/common';
 import {
-  MAT_DIALOG_DATA,
-  MatDialog,
-  MatDialogRef,
-} from '@angular/material/dialog';
+  ZardDialogRef,
+  Z_MODAL_DATA,
+  ZardDialogService,
+} from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
@@ -98,14 +98,15 @@ export class HealthIdDisplayModalComponent implements OnInit, DoCheck {
   healthIDArray: any[] = [];
 
   constructor(
-    public dialogRef: MatDialogRef<HealthIdDisplayModalComponent>,
-    @Inject(MAT_DIALOG_DATA) public input: any,
+    public dialogRef: ZardDialogRef<HealthIdDisplayModalComponent>,
+    @Inject(Z_MODAL_DATA) public input: any,
     public httpServiceService: HttpServiceService,
     private formBuilder: FormBuilder,
     private registrarService: RegistrarService,
     private confirmationService: ConfirmationService,
     private datePipe: DatePipe,
-    private dialogMd: MatDialog,
+    private dialogMd: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     private readonly sessionstorage: SessionStorageService
   ) {
     dialogRef.disableClose = true;
@@ -310,14 +311,17 @@ export class HealthIdDisplayModalComponent implements OnInit, DoCheck {
   }
 
   printHealthIDCard(data: any) {
-    const dialogRefValue = this.dialogMd.open(DownloadSearchAbhaComponent, {
-      height: '330px',
-      width: '500px',
-      disableClose: true,
-      data: {
+    const dialogRefValue = this.dialogMd.create({
+      zContent: DownloadSearchAbhaComponent,
+      zData: {
         printCard: true,
         healthId: data.healthIdNumber,
       },
+      zWidth: '500px',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
   }
 }

--- a/v2/registrar/family-tagging/create-family-tagging/create-family-tagging.component.ts
+++ b/v2/registrar/family-tagging/create-family-tagging/create-family-tagging.component.ts
@@ -26,7 +26,7 @@ import {
   ReactiveFormsModule,
   FormsModule,
 } from '@angular/forms';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { NgIf, NgFor } from '@angular/common';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX } from '@ng-icons/lucide';
@@ -82,13 +82,13 @@ export class CreateFamilyTaggingComponent implements OnInit, DoCheck {
   countryId = 1;
 
   constructor(
-    public matDialogRef: MatDialogRef<CreateFamilyTaggingComponent>,
+    public matDialogRef: ZardDialogRef<CreateFamilyTaggingComponent>,
     public httpServiceService: HttpServiceService,
     private familyTaggingService: FamilyTaggingService,
     private confirmationService: ConfirmationService,
     private fb: FormBuilder,
     private sessionstorage: SessionStorageService,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    @Inject(Z_MODAL_DATA) public data: any,
   ) {}
 
   ngOnInit() {

--- a/v2/registrar/family-tagging/edit-family-tagging/edit-family-tagging.component.ts
+++ b/v2/registrar/family-tagging/edit-family-tagging/edit-family-tagging.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, DoCheck, Inject, OnInit, ViewChild } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { NgIf, NgFor, TitleCasePipe } from '@angular/common';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -90,8 +90,8 @@ export class EditFamilyTaggingComponent implements OnInit, DoCheck {
 
   constructor(
     public httpServiceService: HttpServiceService,
-    public matDialogRef: MatDialogRef<EditFamilyTaggingComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: any,
+    public matDialogRef: ZardDialogRef<EditFamilyTaggingComponent>,
+    @Inject(Z_MODAL_DATA) public data: any,
     private confirmationService: ConfirmationService,
     private familyTaggingService: FamilyTaggingService,
     private sessionstorage: SessionStorageService,

--- a/v2/registrar/family-tagging/family-tagging-details/family-tagging-details.component.ts
+++ b/v2/registrar/family-tagging/family-tagging-details/family-tagging-details.component.ts
@@ -134,8 +134,8 @@ export class FamilyTaggingDetailsComponent
   isEnableES: boolean = false;
 
   constructor(
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     public httpServiceService: HttpServiceService,
     private router: Router,
     private confirmationService: ConfirmationService,

--- a/v2/registrar/family-tagging/family-tagging-details/family-tagging-details.component.ts
+++ b/v2/registrar/family-tagging/family-tagging-details/family-tagging-details.component.ts
@@ -19,8 +19,14 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
-import { Component, DoCheck, OnDestroy, OnInit } from '@angular/core';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import {
+  Component,
+  DoCheck,
+  OnDestroy,
+  OnInit,
+  ViewContainerRef,
+} from '@angular/core';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
@@ -128,7 +134,8 @@ export class FamilyTaggingDetailsComponent
   isEnableES: boolean = false;
 
   constructor(
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     public httpServiceService: HttpServiceService,
     private router: Router,
     private confirmationService: ConfirmationService,
@@ -263,18 +270,24 @@ export class FamilyTaggingDetailsComponent
   }
 
   CreateFamilyDialog() {
-    const matDialogRef: MatDialogRef<CreateFamilyTaggingComponent> =
-      this.dialog.open(CreateFamilyTaggingComponent, {
-        width: '60%',
-        disableClose: true,
-        data: {
-          benFamilyName: this.benFamilyName,
-          benFamilyID: this.benFamilyId,
-          benRegId: this.beneficiaryRegID,
-          beneficiaryName: this.beneficiaryName,
-          benVillageId: this.benVillageId,
-        },
-      });
+    const matDialogRef = this.dialog.create<
+      CreateFamilyTaggingComponent,
+      unknown
+    >({
+      zContent: CreateFamilyTaggingComponent,
+      zData: {
+        benFamilyName: this.benFamilyName,
+        benFamilyID: this.benFamilyId,
+        benRegId: this.beneficiaryRegID,
+        beneficiaryName: this.beneficiaryName,
+        benVillageId: this.benVillageId,
+      },
+      zWidth: '60%',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
+    });
     matDialogRef.afterClosed().subscribe(
       (result) => {
         if (result) {
@@ -332,20 +345,21 @@ export class FamilyTaggingDetailsComponent
   }
 
   openSearchFamily() {
-    const matDialogRef: MatDialogRef<SearchFamilyComponent> = this.dialog.open(
-      SearchFamilyComponent,
-      {
-        width: '60%',
-        disableClose: true,
-        data: {
-          benSurname: this.benFamilyName,
-          benStateId: this.benStateId,
-          benDistrictId: this.benDistrictId,
-          benBlockId: this.benBlockId,
-          benVillageId: this.benVillageId,
-        },
+    const matDialogRef = this.dialog.create<SearchFamilyComponent, unknown>({
+      zContent: SearchFamilyComponent,
+      zData: {
+        benSurname: this.benFamilyName,
+        benStateId: this.benStateId,
+        benDistrictId: this.benDistrictId,
+        benBlockId: this.benBlockId,
+        benVillageId: this.benVillageId,
       },
-    );
+      zWidth: '60%',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
+    });
     matDialogRef.afterClosed().subscribe((result: any) => {
       if (result !== null && result !== undefined) {
         this.familySearchList = result.familyDetails;
@@ -414,11 +428,10 @@ export class FamilyTaggingDetailsComponent
   }
 
   openFamilyTagDialog(isEdit: any, familyDetails: any, familyMembersList: any) {
-    const matDialogRef: MatDialogRef<EditFamilyTaggingComponent> =
-      this.dialog.open(EditFamilyTaggingComponent, {
-        width: '70%',
-        disableClose: true,
-        data: {
+    const matDialogRef = this.dialog.create<EditFamilyTaggingComponent, unknown>(
+      {
+        zContent: EditFamilyTaggingComponent,
+        zData: {
           isEdit: isEdit,
           familyData: familyMembersList,
           beneficiaryRegID: this.beneficiaryRegID,
@@ -426,7 +439,13 @@ export class FamilyTaggingDetailsComponent
           headInFamily: familyDetails.familyHeadName,
           beneficiaryName: this.beneficiaryName,
         },
-      });
+        zWidth: '70%',
+        zMaskClosable: false,
+        zHideFooter: true,
+        zClosable: false,
+        zViewContainerRef: this.viewContainerRef,
+      },
+    );
 
     matDialogRef.afterClosed().subscribe((result) => {
       if (result) {

--- a/v2/registrar/registration.module.ts
+++ b/v2/registrar/registration.module.ts
@@ -6,16 +6,12 @@ import { PersonalInformationComponent } from './registration/personal-informatio
 import { LocationInformationComponent } from './registration/location-information/location-information.component';
 import { OtherInformationComponent } from './registration/other-information/other-information.component';
 import { AbhaInformationComponent } from './registration/abha-information/abha-information.component';
-import { MatStepperModule } from '@angular/material/stepper';
 
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { RegistrationComponent } from './registration/registration.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SearchDialogComponent } from './search-dialog/search-dialog.component';
 import { SearchComponent } from './search/search.component';
-import { MatTableDataSource, MatTableModule } from '@angular/material/table';
-import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MatNativeDateModule } from '@angular/material/core';
 import { RegistrarService } from './services/registrar.service';
 import { RegistrationService } from './services/registration.service';
 import { BiometricAuthenticationComponent } from './abha-components/biometric-authentication/biometric-authentication.component';
@@ -42,13 +38,9 @@ import { AbhaConsentFormComponent } from './abha-components/abha-consent-form/ab
 @NgModule({
     imports: [
     CommonModule,
-    MatStepperModule,
     ReactiveFormsModule,
     FormsModule,
     RegistrationRoutingModule,
-    MatTableModule,
-    MatDatepickerModule,
-    MatNativeDateModule,
     PersonalInformationComponent,
     LocationInformationComponent,
     OtherInformationComponent,

--- a/v2/registrar/registration/abha-information/abha-information.component.ts
+++ b/v2/registrar/registration/abha-information/abha-information.component.ts
@@ -1,7 +1,7 @@
-import { Component, Injector, Input } from '@angular/core';
+import { Component, Injector, Input, ViewContainerRef } from '@angular/core';
 import { Router } from '@angular/router';
 import { RegistrarService } from '../../services/registrar.service';
-import { MatDialog } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { HealthIdDisplayModalComponent } from '../../abha-components/health-id-display-modal/health-id-display-modal.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
@@ -52,7 +52,8 @@ export class AbhaInformationComponent {
   constructor(
     private router: Router,
     private registrarService: RegistrarService,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     private confirmationService: ConfirmationService,
     private httpServiceService: HttpServiceService,
     private languageComponent: SetLanguageComponent,
@@ -113,8 +114,12 @@ export class AbhaInformationComponent {
     this.registrarService.getHealthIdDetails(reqObj).subscribe(
       (res: any) => {
         if (res.statusCode === 200) {
-          this.dialog.open(HealthIdDisplayModalComponent, {
-            data: { dataList: res },
+          this.dialog.create({
+            zContent: HealthIdDisplayModalComponent,
+            zData: { dataList: res },
+            zHideFooter: true,
+            zClosable: false,
+            zViewContainerRef: this.viewContainerRef,
           });
         } else {
           this.confirmationService.alert(
@@ -187,18 +192,27 @@ export class AbhaInformationComponent {
   }
 
   healthIdSearch() {
-    const dialog = this.dialog.open(AbhaConsentFormComponent, {
-      height: 'auto',
-      width: 'auto',
-      disableClose: true
+    const dialog = this.dialog.create<AbhaConsentFormComponent, unknown>({
+      zContent: AbhaConsentFormComponent,
+      zWidth: 'auto',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
     dialog.afterClosed().subscribe(res => {
       console.log("download consent after response -", res);
       if (res) {
-        const dialogRef = this.dialog.open(DownloadSearchAbhaComponent, {
-          height: '330px',
-          width: '500px',
-          disableClose: true,
+        const dialogRef = this.dialog.create<
+          DownloadSearchAbhaComponent,
+          unknown
+        >({
+          zContent: DownloadSearchAbhaComponent,
+          zWidth: '500px',
+          zMaskClosable: false,
+          zHideFooter: true,
+          zClosable: false,
+          zViewContainerRef: this.viewContainerRef,
         });
         dialogRef.afterClosed().subscribe((result) => {
           if (result) {
@@ -225,18 +239,24 @@ export class AbhaInformationComponent {
   }
 
   generateAbhaCard() {
-    const dialogRef = this.dialog.open(AbhaConsentFormComponent, {
-      height: 'auto',
-      width: 'auto',
-      disableClose: true
+    const dialogRef = this.dialog.create<AbhaConsentFormComponent, unknown>({
+      zContent: AbhaConsentFormComponent,
+      zWidth: 'auto',
+      zMaskClosable: false,
+      zHideFooter: true,
+      zClosable: false,
+      zViewContainerRef: this.viewContainerRef,
     });
     dialogRef.afterClosed().subscribe(res => {
       console.log("consent after response -", res);
       if (res) {
-        this.dialog.open(GenerateAbhaComponentComponent, {
-          height: '340px',
-          width: '500px',
-          disableClose: true,
+        this.dialog.create({
+          zContent: GenerateAbhaComponentComponent,
+          zWidth: '500px',
+          zMaskClosable: false,
+          zHideFooter: true,
+          zClosable: false,
+          zViewContainerRef: this.viewContainerRef,
         });
       }
     });

--- a/v2/registrar/registration/abha-information/abha-information.component.ts
+++ b/v2/registrar/registration/abha-information/abha-information.component.ts
@@ -52,8 +52,8 @@ export class AbhaInformationComponent {
   constructor(
     private router: Router,
     private registrarService: RegistrarService,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     private confirmationService: ConfirmationService,
     private httpServiceService: HttpServiceService,
     private languageComponent: SetLanguageComponent,

--- a/v2/registrar/registration/consent-form/consent-form.component.ts
+++ b/v2/registrar/registration/consent-form/consent-form.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 import { Component, Inject, OnInit } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { Router } from '@angular/router';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideX } from '@ng-icons/lucide';
@@ -40,10 +40,10 @@ export class ConsentFormComponent implements OnInit {
   currentLanguageSet: any;
 
   constructor(
-    @Inject(MAT_DIALOG_DATA) public data: Consent,
+    @Inject(Z_MODAL_DATA) public data: Consent,
     private router: Router,
     public httpServiceService: HttpServiceService,
-    public matDialogRef: MatDialogRef<ConsentFormComponent>,
+    public matDialogRef: ZardDialogRef<ConsentFormComponent>,
   ) {}
 
   ngOnInit(): void {

--- a/v2/registrar/registration/other-information/other-information.component.ts
+++ b/v2/registrar/registration/other-information/other-information.component.ts
@@ -75,7 +75,7 @@ export class OtherInformationComponent {
     private readonly fb: FormBuilder,
     private registrarService: RegistrarService,
     private readonly dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly viewContainerRef: ViewContainerRef,
   ) {}
 
   ngOnInit() {

--- a/v2/registrar/registration/other-information/other-information.component.ts
+++ b/v2/registrar/registration/other-information/other-information.component.ts
@@ -20,7 +20,7 @@
  * along with this program.  If not, see https://www.gnu.org/licenses/.
  */
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewContainerRef } from '@angular/core';
 import {
   FormBuilder,
   FormControl,
@@ -30,7 +30,7 @@ import {
 } from '@angular/forms';
 import { RegistrarService } from '../../services/registrar.service';
 import { Subscription } from 'rxjs';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { ConsentFormComponent } from '../consent-form/consent-form.component';
 import { NgFor, NgIf } from '@angular/common';
 import { ZardFormImports } from 'Common-UI/v2/ui/form';
@@ -74,7 +74,8 @@ export class OtherInformationComponent {
   constructor(
     private readonly fb: FormBuilder,
     private registrarService: RegistrarService,
-    private readonly dialog: MatDialog,
+    private readonly dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
   ) {}
 
   ngOnInit() {
@@ -151,14 +152,14 @@ export class OtherInformationComponent {
 
   openConsent() {
     if (this.patientRevisit === false) {
-      const matDialogRef: MatDialogRef<ConsentFormComponent> = this.dialog.open(
-        ConsentFormComponent,
-        {
-          width: '650px',
-          height: '700px',
-          disableClose: true,
-        },
-      );
+      const matDialogRef = this.dialog.create<ConsentFormComponent, unknown>({
+        zContent: ConsentFormComponent,
+        zWidth: '650px',
+        zMaskClosable: false,
+        zHideFooter: true,
+        zClosable: false,
+        zViewContainerRef: this.viewContainerRef,
+      });
       matDialogRef.afterClosed().subscribe((consentProvided) => {
         this.consentGranted = consentProvided;
         this.registrarService.sendConsentStatus(consentProvided);

--- a/v2/registrar/registration/registration.component.ts
+++ b/v2/registrar/registration/registration.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ViewContainerRef } from '@angular/core';
+import { Component, ViewContainerRef } from '@angular/core';
 import { RegistrationService } from '../services/registration.service';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators, ReactiveFormsModule } from '@angular/forms';
@@ -59,8 +59,8 @@ export class RegistrationComponent {
     private httpServiceService: HttpServiceService,
     private sessionstorage:SessionStorageService,
     private router: Router,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef, ){
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef, ){
     this.mainForm = this.fb.group({
       // personalInfoForm: this.fb.group({}),
       personalInfoForm: this.fb.group({

--- a/v2/registrar/registration/registration.component.ts
+++ b/v2/registrar/registration/registration.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, ViewContainerRef } from '@angular/core';
 import { RegistrationService } from '../services/registration.service';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { AbstractControl, FormBuilder, FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators, ReactiveFormsModule } from '@angular/forms';
@@ -8,7 +8,7 @@ import { Subscription } from 'rxjs';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { HttpServiceService } from 'src/app/app-modules/core/services/http-service.service';
 import * as moment from 'moment';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { ConsentFormComponent } from './consent-form/consent-form.component';
 import { SessionStorageService } from '../services/session-storage.service';
 import { NgIf } from '@angular/common';
@@ -59,7 +59,8 @@ export class RegistrationComponent {
     private httpServiceService: HttpServiceService,
     private sessionstorage:SessionStorageService,
     private router: Router,
-    private dialog: MatDialog, ){
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef, ){
     this.mainForm = this.fb.group({
       // personalInfoForm: this.fb.group({}),
       personalInfoForm: this.fb.group({
@@ -197,14 +198,13 @@ export class RegistrationComponent {
 
   openConsent() {
     if (this.patientRevisit === false) {
-      const mdDialogRef: MatDialogRef<ConsentFormComponent> = this.dialog.open(
-        ConsentFormComponent,
-        {
-          width: '50%',
-          height: '330px',
-          // disableClose: true,
-        },
-      );
+      const mdDialogRef = this.dialog.create<ConsentFormComponent, unknown>({
+        zContent: ConsentFormComponent,
+        zWidth: '50%',
+        zHideFooter: true,
+        zClosable: false,
+        zViewContainerRef: this.viewContainerRef,
+      });
       mdDialogRef.afterClosed().subscribe((consentProvided) => {
         this.consentGranted = consentProvided;
         this.registrarService.sendConsentStatus(consentProvided);

--- a/v2/registrar/search-dialog/search-dialog.component.ts
+++ b/v2/registrar/search-dialog/search-dialog.component.ts
@@ -28,7 +28,7 @@ import {
   FormControl,
   ReactiveFormsModule,
 } from '@angular/forms';
-import { MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogRef } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
 import { CommonService } from 'src/app/app-modules/core/services/common-services.service';
@@ -118,7 +118,7 @@ export class SearchDialogComponent implements OnInit, DoCheck {
 
   constructor(
     private confirmationService: ConfirmationService,
-    public matDialogRef: MatDialogRef<SearchDialogComponent>,
+    public matDialogRef: ZardDialogRef<SearchDialogComponent>,
     public commonService: CommonService,
     private fb: FormBuilder,
     private httpServiceService: HttpServiceService,

--- a/v2/registrar/search-family/search-family.component.ts
+++ b/v2/registrar/search-family/search-family.component.ts
@@ -27,10 +27,7 @@ import {
   HostListener,
   DoCheck,
 } from '@angular/core';
-import {
-  MatDialogRef,
-  MAT_DIALOG_DATA,
-} from '@angular/material/dialog';
+import { ZardDialogRef, Z_MODAL_DATA } from 'Common-UI/v2/ui/dialog';
 import { Router } from '@angular/router';
 import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
 import { ConfirmationService } from 'src/app/app-modules/core/services';
@@ -107,13 +104,13 @@ export class SearchFamilyComponent implements OnInit, DoCheck {
     private confirmationService: ConfirmationService,
     private formBuilder: FormBuilder,
     public httpServiceService: HttpServiceService,
-    public matDialogRef: MatDialogRef<SearchFamilyComponent>,
+    public matDialogRef: ZardDialogRef<SearchFamilyComponent>,
     public commonService: CommonService,
     private router: Router,
     private registrarService: RegistrarService,
     private changeDetectorRef: ChangeDetectorRef,
     private familyTaggingService: FamilyTaggingService,
-    @Inject(MAT_DIALOG_DATA) public data: any
+    @Inject(Z_MODAL_DATA) public data: any
   ) {}
 
   ngOnInit() {

--- a/v2/registrar/search/search.component.ts
+++ b/v2/registrar/search/search.component.ts
@@ -27,10 +27,11 @@ import {
   DoCheck,
   AfterViewChecked,
   OnDestroy,
+  ViewContainerRef,
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { SearchDialogComponent } from '../search-dialog/search-dialog.component';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ZardDialogService } from 'Common-UI/v2/ui/dialog';
 import { SetLanguageComponent } from 'src/app/app-modules/core/components/set-language.component';
 import {
   ConfirmationService,
@@ -122,7 +123,8 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
-    private dialog: MatDialog,
+    private dialog: ZardDialogService,
+    private viewContainerRef: ViewContainerRef,
     private httpServiceService: HttpServiceService,
     private confirmationService: ConfirmationService,
     private registrarService: RegistrarService,
@@ -400,8 +402,12 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
       data.benObject.abhaDetails.length > 0
     ) 
     {
-      this.dialog.open(HealthIdDisplayModalComponent, {
-        data: { dataList: data.benObject.abhaDetails[0], search: true },
+      this.dialog.create({
+        zContent: HealthIdDisplayModalComponent,
+        zData: { dataList: data.benObject.abhaDetails[0], search: true },
+        zHideFooter: true,
+        zClosable: false,
+        zViewContainerRef: this.viewContainerRef,
       });
     } else
       this.confirmationService.alert(
@@ -575,13 +581,14 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
   }
 
   openSearchDialog() {
-  const mdDialogRef: MatDialogRef<SearchDialogComponent> = this.dialog.open(
-    SearchDialogComponent,
-    {
-      width: '60%',
-      disableClose: false,
-    },
-  );
+  const mdDialogRef = this.dialog.create<SearchDialogComponent, unknown>({
+    zContent: SearchDialogComponent,
+    zWidth: '60%',
+    zMaskClosable: true,
+    zHideFooter: true,
+    zClosable: false,
+    zViewContainerRef: this.viewContainerRef,
+  });
 
   mdDialogRef.afterClosed().subscribe((result) => {
     if (result) {

--- a/v2/registrar/search/search.component.ts
+++ b/v2/registrar/search/search.component.ts
@@ -123,8 +123,8 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
-    private dialog: ZardDialogService,
-    private viewContainerRef: ViewContainerRef,
+    private readonly dialog: ZardDialogService,
+    private readonly viewContainerRef: ViewContainerRef,
     private httpServiceService: HttpServiceService,
     private confirmationService: ConfirmationService,
     private registrarService: RegistrarService,

--- a/v2/registrar/services/rddevice.service.ts
+++ b/v2/registrar/services/rddevice.service.ts
@@ -1,32 +1,63 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import * as $ from 'jquery';
 
 @Injectable({ providedIn: 'root' })
 export class RdDeviceService {
-  rdURL='';
-  MethodInfo='/rd/info';
+  rdURL = '';
+  MethodInfo = '/rd/info';
   MethodCapture = '/rd/capture';
   httpStaus: boolean = false;
   capturePID: any;
-  pidDetail: any= null ;
+  pidDetail: any = null;
   pidDetailData = new BehaviorSubject<any>(this.pidDetail);
   pidDetailDetails$ = this.pidDetailData.asObservable();
   pidResponseData: any;
 
   constructor(private http: HttpClient) {}
+
+  /**
+   * Synchronous request to the local RD (Registered Device) service, which uses
+   * non-standard HTTP verbs (RDSERVICE / DEVICEINFO / CAPTURE). Mirrors the
+   * previous jQuery `$.ajax({ async: false, processData: false })` behaviour with
+   * a native XMLHttpRequest (kept synchronous so callers get the response inline).
+   */
+  private rdRequest(type: string, url: string, data?: string): string {
+    const xhr = new XMLHttpRequest();
+    xhr.open(type, url, false);
+    xhr.setRequestHeader('Content-Type', 'text/xml; charset=utf-8');
+    xhr.send(data ?? null);
+    if (xhr.status < 200 || xhr.status >= 300) {
+      throw new Error(xhr.statusText || 'RD device request failed');
+    }
+    return xhr.responseText;
+  }
+
+  /** Set the value of a (possibly absent) input by id — matches jQuery `$('#id').val(v)`. */
+  private setInputValue(id: string, value: string): void {
+    const el = document.getElementById(id) as HTMLInputElement | null;
+    if (el) {
+      el.value = value;
+    }
+  }
+
   discoverAvdm(): Observable<any> {
     const primaryUrl =
       window.location.protocol === 'https:'
         ? 'https://127.0.0.1:'
         : 'http://127.0.0.1:';
     const discoveryRange = Array.from({ length: 21 }, (_, i) => i + 11101);
-    return new Observable((observer) => {
+    return new Observable(observer => {
       this.discoverRecursive(observer, primaryUrl, discoveryRange, 0);
     });
   }
-  private discoverRecursive(observer: any, primaryUrl: any, discoveryRange: any, index: any) {
+
+  private discoverRecursive(
+    observer: any,
+    primaryUrl: any,
+    discoveryRange: any,
+    index: any
+  ) {
     if (index >= discoveryRange.length) {
       observer.error('Connection failed. Please try again.');
       observer.complete();
@@ -36,114 +67,96 @@ export class RdDeviceService {
     const url = `${primaryUrl}${port}`;
     this.rdURL = `${primaryUrl}${port}`;
 
-    $.ajax({
-      type: 'RDSERVICE',
-      async: false,
-      crossDomain: true,
-      url: primaryUrl + '11101',
-      contentType: 'text/xml; charset=utf-8',
-      processData: false,
-      cache: false,
-      success: (data: any) => {
-        this.httpStaus = true;
-        const res = { httpStaus: this.httpStaus, data: data };
-        const finalUrl = primaryUrl + '11101';
-        const $doc = $.parseXML(data);
-        const CmbData1 = $($doc).find('RDService').attr('status') || '';
-        const CmbData2 = $($doc).find('RDService').attr('info')|| '';
-        if (RegExp('\\b' + 'Mantra' + '\\b').test(CmbData2) == true) {
-          $('#txtDeviceInfo').val(data);
-          if ($($doc).find('Interface').eq(0).attr('path') == '/rd/capture') {
-            this.MethodCapture = $($doc).find('Interface').eq(0).attr('path') || '';
-            console.log(this.MethodCapture);
-          }
-          if ($($doc).find('Interface').eq(0).attr('path') == '/rd/info') {
-            this.MethodInfo = $($doc).find('Interface').eq(0).attr('path') || ''
-            ;
-            console.log(this.MethodInfo);
-          }
-          $('#ddlAVDM').append(
-            '<option value=' +
-              '11101' +
-              '>(' +
-              CmbData1 +
-              ')' +
-              CmbData2 +
-              '</option>',
-          );
-          observer.next(res);
-          observer.complete();
-        } else {
-          this.discoverRecursive(
-            observer,
-            primaryUrl,
-            discoveryRange,
-            index + 1,
-          );
-        }
-      },
-      error: (jqXHR: any, ajaxOptions: any, thrownError: any) => {
-        this.discoverRecursive(observer, primaryUrl, discoveryRange, index + 1);
-      },
-    });
+    let data: string;
+    try {
+      data = this.rdRequest('RDSERVICE', primaryUrl + '11101');
+    } catch (thrownError) {
+      this.discoverRecursive(observer, primaryUrl, discoveryRange, index + 1);
+      return;
+    }
+
+    this.httpStaus = true;
+    const res = { httpStaus: this.httpStaus, data: data };
+    const finalUrl = primaryUrl + '11101';
+    const doc = new DOMParser().parseFromString(data, 'text/xml');
+    const CmbData1 =
+      doc.querySelector('RDService')?.getAttribute('status') || '';
+    const CmbData2 = doc.querySelector('RDService')?.getAttribute('info') || '';
+    if (RegExp('\\b' + 'Mantra' + '\\b').test(CmbData2) == true) {
+      this.setInputValue('txtDeviceInfo', data);
+      const interfaces = doc.querySelectorAll('Interface');
+      if (interfaces[0]?.getAttribute('path') == '/rd/capture') {
+        this.MethodCapture = interfaces[0]?.getAttribute('path') || '';
+        console.log(this.MethodCapture);
+      }
+      if (interfaces[0]?.getAttribute('path') == '/rd/info') {
+        this.MethodInfo = interfaces[0]?.getAttribute('path') || '';
+        console.log(this.MethodInfo);
+      }
+      const ddlAVDM = document.getElementById('ddlAVDM');
+      if (ddlAVDM) {
+        ddlAVDM.insertAdjacentHTML(
+          'beforeend',
+          '<option value=' +
+            '11101' +
+            '>(' +
+            CmbData1 +
+            ')' +
+            CmbData2 +
+            '</option>'
+        );
+      }
+      observer.next(res);
+      observer.complete();
+    } else {
+      this.discoverRecursive(observer, primaryUrl, discoveryRange, index + 1);
+    }
   }
+
   getDeviceInfo(): Observable<any> {
     const finalUrl = this.rdURL + this.MethodInfo;
-    return new Observable((observer) => {
-      $.ajax({
-        type: 'DEVICEINFO',
-        async: false,
-        crossDomain: true,
-        url: finalUrl,
-        contentType: 'text/xml; charset=utf-8',
-        processData: false,
-        success: (data: any) => {
-          this.httpStaus = true;
-          const res = { httpStaus: this.httpStaus, data: data };
-          console.log(res);
-          $('#txtDeviceInfo').val(data);
-          observer.next(res);
-          observer.complete();
-        },
-        error: (jqXHR: any, ajaxOptions: any, thrownError: any) => {
-          const res = { httpStaus: this.httpStaus, err: thrownError };
-          observer.error(res);
-        },
-      });
+    return new Observable(observer => {
+      let data: string;
+      try {
+        data = this.rdRequest('DEVICEINFO', finalUrl);
+      } catch (thrownError) {
+        observer.error({ httpStaus: this.httpStaus, err: thrownError });
+        return;
+      }
+      this.httpStaus = true;
+      const res = { httpStaus: this.httpStaus, data: data };
+      console.log(res);
+      this.setInputValue('txtDeviceInfo', data);
+      observer.next(res);
+      observer.complete();
     });
   }
+
   captureAvdm(): Observable<any> {
     const finalUrl = this.rdURL + this.MethodCapture;
     const requestData =
       '<PidOptions ver="1.0">\r\n<Opts env="P" fCount="1" fType="2" format="0" iType="" pCount="0" pidVer="2.0" posh="UNKNOWN" timeout="20000" wadh="E0jzJ/P8UopUHAieZn8CKqS4WPMi5ZSYXgfnlfkWjrc="/></PidOptions>';
-    return new Observable((observer) => {
-      $.ajax({
-        type: 'CAPTURE',
-        async: false,
-        crossDomain: true,
-        url: finalUrl,
-        data: requestData,
-        contentType: 'text/xml; charset=utf-8',
-        processData: false,
-        success: (data: any) => {
-          this.httpStaus = true;
-          const res = { httpStaus: this.httpStaus, data: data };
-          console.log("unecripted data - ", data)
-          const encodedPIDRes = btoa(data);
-          console.log("encrypted data", encodedPIDRes);
-          $('#txtPidData').val(encodedPIDRes);
-          $('#txtPidOptions').val(encodedPIDRes);
-          this.getpidDetail(encodedPIDRes);
-          observer.next(encodedPIDRes);
-          observer.complete();
-        },
-        error: (jqXHR: any, ajaxOptions: any, thrownError: any) => {
-          const res = { httpStaus: this.httpStaus, err: thrownError };
-          observer.error(res);
-        },
-      });
+    return new Observable(observer => {
+      let data: string;
+      try {
+        data = this.rdRequest('CAPTURE', finalUrl, requestData);
+      } catch (thrownError) {
+        observer.error({ httpStaus: this.httpStaus, err: thrownError });
+        return;
+      }
+      this.httpStaus = true;
+      const res = { httpStaus: this.httpStaus, data: data };
+      console.log('unecripted data - ', data);
+      const encodedPIDRes = btoa(data);
+      console.log('encrypted data', encodedPIDRes);
+      this.setInputValue('txtPidData', encodedPIDRes);
+      this.setInputValue('txtPidOptions', encodedPIDRes);
+      this.getpidDetail(encodedPIDRes);
+      observer.next(encodedPIDRes);
+      observer.complete();
     });
   }
+
   getpidDetail(pidDetailDetails: any) {
     this.pidDetail = pidDetailDetails;
     this.pidDetailData.next(this.pidDetail);

--- a/v2/ui/dialog/dialog-ref.ts
+++ b/v2/ui/dialog/dialog-ref.ts
@@ -59,7 +59,9 @@ export class ZardDialogRef<T = any, R = any, U = any> {
       this.overlayRef
         .outsidePointerEvents()
         .pipe(takeUntil(this.destroy$))
-        .subscribe(() => this.close());
+        .subscribe(() => {
+          if (!this.disableClose) this.close();
+        });
     }
 
     if (isPlatformBrowser(this.platformId)) {
@@ -68,7 +70,9 @@ export class ZardDialogRef<T = any, R = any, U = any> {
           filter(event => event.key === 'Escape'),
           takeUntil(this.destroy$),
         )
-        .subscribe(() => this.close());
+        .subscribe(() => {
+          if (!this.disableClose) this.close();
+        });
     }
   }
 

--- a/v2/ui/dialog/dialog-ref.ts
+++ b/v2/ui/dialog/dialog-ref.ts
@@ -36,6 +36,12 @@ const enum eTriggerAction {
 export class ZardDialogRef<T = any, R = any, U = any> {
   private destroy$ = new Subject<void>();
   private readonly afterClosed$ = new Subject<R | undefined>();
+  /**
+   * When true, backdrop clicks and the Escape key do not close the dialog.
+   * Parity with MatDialogRef.disableClose so dialogs migrated off Material can
+   * keep marking themselves non-dismissible.
+   */
+  disableClose = false;
   private isClosing = false;
   protected result?: R;
   componentInstance: T | null = null;

--- a/v2/ui/dialog/dialog.component.ts
+++ b/v2/ui/dialog/dialog.component.ts
@@ -35,13 +35,14 @@ import {
   computed,
   ElementRef,
   type EmbeddedViewRef,
+  EnvironmentInjector,
   type EventEmitter,
   inject,
   output,
   type TemplateRef,
   type Type,
   viewChild,
-  type ViewContainerRef,
+  ViewContainerRef,
 } from '@angular/core';
 
 import { NgIcon, provideIcons } from '@ng-icons/core';
@@ -106,6 +107,7 @@ export class ZardDialogOptions<T, U> {
     }
 
     <main class="flex flex-col space-y-4">
+      <ng-container #contentAnchor />
       <ng-template cdkPortalOutlet />
 
       @if (isStringContent) {
@@ -188,6 +190,9 @@ export class ZardDialogComponent<T, U> extends BasePortalOutlet {
   protected readonly isStringContent = typeof this.config.zContent === 'string';
 
   readonly portalOutlet = viewChild.required(CdkPortalOutlet);
+  readonly contentAnchor = viewChild.required('contentAnchor', {
+    read: ViewContainerRef,
+  });
 
   okTriggered = output<void>();
   cancelTriggered = output<void>();
@@ -201,10 +206,22 @@ export class ZardDialogComponent<T, U> extends BasePortalOutlet {
   }
 
   attachComponentPortal<T>(portal: ComponentPortal<T>): ComponentRef<T> {
-    if (this.portalOutlet()?.hasAttached()) {
+    const viewContainerRef = this.contentAnchor();
+    if (viewContainerRef.length > 0) {
       throw new Error('Attempting to attach modal content after content is already attached');
     }
-    return this.portalOutlet()?.attachComponentPortal(portal);
+    // Create the content with an explicit environmentInjector taken from the
+    // caller's injector (whose parent is the opener's ViewContainerRef injector),
+    // so route/feature-scoped providers (DoctorService, MasterdataService, …)
+    // resolve inside the dialog. Delegating to CdkPortalOutlet.attachComponentPortal
+    // instead forces `ngModuleRef` to the overlay's (root) environment injector,
+    // which drops those providers and throws NG0201.
+    const injector = portal.injector ?? viewContainerRef.injector;
+    const environmentInjector = injector.get(EnvironmentInjector);
+    return viewContainerRef.createComponent(portal.component, {
+      injector,
+      environmentInjector,
+    });
   }
 
   attachTemplatePortal<C>(portal: TemplatePortal<C>): EmbeddedViewRef<C> {

--- a/v2/ui/dialog/dialog.service.ts
+++ b/v2/ui/dialog/dialog.service.ts
@@ -47,9 +47,16 @@ export class ZardDialogService {
   private overlay = inject(Overlay);
   private injector = inject(Injector);
   private platformId = inject(PLATFORM_ID);
+  private readonly openDialogs = new Set<ZardDialogRef>();
 
   create<T, U>(config: ZardDialogOptions<T, U>): ZardDialogRef<T> {
     return this.open<T, U>(config.zContent as ComponentType<T>, config);
+  }
+
+  /** Closes every currently-open dialog. Parity with MatDialog.closeAll(). */
+  closeAll(): void {
+    this.openDialogs.forEach(ref => ref.close());
+    this.openDialogs.clear();
   }
 
   private open<T, U>(componentOrTemplateRef: ContentType<T>, config: ZardDialogOptions<T, U>) {
@@ -68,6 +75,9 @@ export class ZardDialogService {
     const dialogRef = this.attachDialogContent<T, U>(componentOrTemplateRef, dialogContainer, overlayRef, config);
 
     dialogContainer.dialogRef = dialogRef;
+
+    this.openDialogs.add(dialogRef);
+    dialogRef.afterClosed().subscribe(() => this.openDialogs.delete(dialogRef));
 
     return dialogRef;
   }

--- a/v2/ui/select/select.variants.ts
+++ b/v2/ui/select/select.variants.ts
@@ -26,14 +26,14 @@ import { mergeClasses } from '../utils/merge-classes';
 
 export const selectVariants = cva(
   mergeClasses(
-    'relative inline-block w-full rounded-md group data-active:border data-active:border-ring data-active:ring-ring/50 data-active:ring-[3px]',
+    'relative inline-block w-full rounded-lg group data-active:border data-active:border-ring data-active:ring-ring/50 data-active:ring-[3px]',
     '[&_button]:focus-visible:border [&_button]:focus-visible:border-ring [&_button]:focus-visible:ring-ring/50 [&_button]:focus-visible:ring-[3px]',
   ),
 );
 
 export const selectTriggerVariants = cva(
   mergeClasses(
-    'flex w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent',
+    'flex w-full items-center justify-between gap-2 rounded-lg border border-input bg-transparent',
     'shadow-xs transition-[color,box-shadow] outline-none cursor-pointer disabled:cursor-not-allowed',
     'disabled:opacity-50 data-placeholder:text-muted-foreground [&_svg:not([class*="text-"])]:text-muted-foreground',
     'dark:bg-input/30 dark:hover:bg-input/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',


### PR DESCRIPTION
## What
Migrates all v2 **registrar** dialog usages off Angular Material's `MatDialog` to the app's `ZardDialogService` — the ABHA flow, family-tagging, registration, and search dialogs (21 components).

## How
- **Openers**: `dialog.open(Cmp, { data, width, disableClose })` → `dialogService.create({ zContent, zData, zWidth, zMaskClosable, zHideFooter: true, zClosable: false, zViewContainerRef })`. `.afterClosed().subscribe(result => …)` is unchanged (uses `ZardDialogRef.afterClosed()` from #72).
- **Dialog components**: `MatDialogRef` → `ZardDialogRef`, `MAT_DIALOG_DATA` → `Z_MODAL_DATA`; `close(result)` unchanged.
- Adds a `disableClose` flag to `ZardDialogRef` (guards backdrop + Escape) so the ABHA OTP/mobile modals stay non-dismissible exactly as before.

## Result
- **0** `@angular/material/dialog` usages remain in `v2`.
- AOT build is green.

## Notes / faithful-reskin caveats
- `height` options were dropped — `ZardDialogOptions` has no height field, so dialogs now size to content. Flag if any specific dialog needs a fixed height.
- A few dead, unused `MatDialog` injections were removed.
- Stacked on #72 (`feat/zard-dialog-enhancements`); retarget after that merges.
