### PR TITLE
refactor(ui): remove last Angular Material import from Common-UI v2

### DIFF
--- a/v2/registrar/registration.module.ts
+++ b/v2/registrar/registration.module.ts
@@ -6,16 +6,12 @@ import { PersonalInformationComponent } from './registration/personal-informatio
 import { LocationInformationComponent } from './registration/location-information/location-information.component';
 import { OtherInformationComponent } from './registration/other-information/other-information.component';
 import { AbhaInformationComponent } from './registration/abha-information/abha-information.component';
-import { MatStepperModule } from '@angular/material/stepper';
 
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { RegistrationComponent } from './registration/registration.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { SearchDialogComponent } from './search-dialog/search-dialog.component';
 import { SearchComponent } from './search/search.component';
-import { MatTableDataSource, MatTableModule } from '@angular/material/table';
-import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MatNativeDateModule } from '@angular/material/core';
 import { RegistrarService } from './services/registrar.service';
 import { RegistrationService } from './services/registration.service';
 import { BiometricAuthenticationComponent } from './abha-components/biometric-authentication/biometric-authentication.component';
@@ -42,13 +38,9 @@ import { AbhaConsentFormComponent } from './abha-components/abha-consent-form/ab
 @NgModule({
     imports: [
     CommonModule,
-    MatStepperModule,
     ReactiveFormsModule,
     FormsModule,
     RegistrationRoutingModule,
-    MatTableModule,
-    MatDatepickerModule,
-    MatNativeDateModule,
     PersonalInformationComponent,
     LocationInformationComponent,
     OtherInformationComponent,


### PR DESCRIPTION
## What
Removes the last `@angular/material` reference from `Common-UI/v2`.

`registration.module.ts` is a leftover pre-standalone `NgModule` that **nothing imports** (`RegistrationModule` is unreferenced — the registrar runs as standalone components). It still imported `MatStepperModule` / `MatTableModule` / `MatDatepickerModule` / `MatNativeDateModule`, none of which any v2 template uses (v2 has 0 `mat-*` elements). Those imports are dropped.

## Result
- **`Common-UI/v2` now imports 0 `@angular/material`** and uses 0 Bootstrap classes.
- Combined with #72 (dialog engine) and #73 (registrar dialogs), `v2` is fully off Angular Material — clearing the way for the consuming apps to drop the dependency.

## Notes
- The dead module file itself is left in place (not deleted) to stay conservative; it simply no longer references Material.
- Stacked on #73; retarget after that merges.
