### PR TITLE
fix(ui): shadcn-faithful form message colors + table header style

### DIFF
--- a/v2/ui/form/form.component.ts
+++ b/v2/ui/form/form.component.ts
@@ -66,7 +66,7 @@ export class ZardFormFieldComponent {
     @if (errorMessage() || helpText()) {
       <div class="mt-1.5 min-h-5">
         @if (errorMessage()) {
-          <p class="text-sm text-red-500">{{ errorMessage() }}</p>
+          <p class="text-sm text-destructive">{{ errorMessage() }}</p>
         } @else if (helpText()) {
           <p class="text-muted-foreground text-sm">{{ helpText() }}</p>
         }

--- a/v2/ui/form/form.variants.ts
+++ b/v2/ui/form/form.variants.ts
@@ -32,7 +32,7 @@ export const formLabelVariants = cva(
   {
     variants: {
       zRequired: {
-        true: "after:content-['*'] after:ml-0.5 after:text-red-500",
+        true: "after:content-['*'] after:ml-0.5 after:text-destructive",
       },
     },
   },
@@ -44,8 +44,8 @@ export const formMessageVariants = cva('text-sm', {
   variants: {
     zType: {
       default: 'text-muted-foreground',
-      error: 'text-red-500',
-      success: 'text-green-500',
+      error: 'text-destructive',
+      success: 'text-success',
       warning: 'text-yellow-500',
     },
   },

--- a/v2/ui/table/table.variants.ts
+++ b/v2/ui/table/table.variants.ts
@@ -23,7 +23,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 
 export const tableVariants = cva(
-  'w-full caption-bottom text-sm [&_thead_tr]:border-b [&_tbody]:border-0 [&_tbody_tr:last-child]:border-0 [&_tbody_tr]:border-b [&_tbody_tr]:transition-colors [&_tbody_tr]:hover:bg-muted/50 [&_tbody_tr]:data-[state=selected]:bg-muted [&_th]:h-10 [&_th]:px-2 [&_th]:text-left [&_th]:align-middle [&_th]:font-bold [&_th]:text-muted-foreground [&_th:has([role=checkbox])]:pr-0 [&_th>[role=checkbox]]:translate-y-0.5 [&_td]:p-2 [&_td]:align-middle [&_td:has([role=checkbox])]:pr-0 [&_td>[role=checkbox]]:translate-y-0.5 [&_caption]:mt-4 [&_caption]:text-sm [&_caption]:text-muted-foreground',
+  'w-full caption-bottom text-sm [&_thead_tr]:border-b [&_tbody]:border-0 [&_tbody_tr:last-child]:border-0 [&_tbody_tr]:border-b [&_tbody_tr]:transition-colors [&_tbody_tr]:hover:bg-muted/50 [&_tbody_tr]:data-[state=selected]:bg-muted [&_th]:h-10 [&_th]:px-2 [&_th]:text-left [&_th]:align-middle [&_th]:font-medium [&_th]:text-foreground [&_th:has([role=checkbox])]:pr-0 [&_th>[role=checkbox]]:translate-y-0.5 [&_td]:p-2 [&_td]:align-middle [&_td:has([role=checkbox])]:pr-0 [&_td>[role=checkbox]]:translate-y-0.5 [&_caption]:mt-4 [&_caption]:text-sm [&_caption]:text-muted-foreground',
   {
     variants: {
       zType: {
@@ -60,7 +60,7 @@ export const tableRowVariants = cva('border-b transition-colors hover:bg-muted/5
 });
 
 export const tableHeadVariants = cva(
-  'h-10 px-2 text-left align-middle font-bold text-muted-foreground [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5',
+  'h-10 px-2 text-left align-middle font-medium text-foreground [&:has([role=checkbox])]:pr-0 *:[[role=checkbox]]:translate-y-0.5',
   {
     variants: {},
     defaultVariants: {},


### PR DESCRIPTION
Two component-level deviations from stock shadcn, found while auditing the migrated apps against the real shadcn docs:

- **Form messages** used raw `text-red-500`/`text-green-500` — shadcn's styling rules require semantic tokens (`text-destructive`/`text-success`) for status colors so they follow the theme (and dark mode)
- **Table headers** used `font-bold text-muted-foreground` — stock shadcn `TableHead` is `font-medium text-foreground` (crisp dark medium-weight headers)

Benefits every consumer (MMU-UI, Inventory-UI) on the next submodule bump. No API change.