### PR TITLE
feat(select): forward aria-label/aria-labelledby to the combobox trigger

### DIFF
--- a/v2/ui/select/select.component.ts
+++ b/v2/ui/select/select.component.ts
@@ -79,6 +79,8 @@ const COMPACT_MODE_WIDTH_THRESHOLD = 100;
       aria-controls="dropdown"
       [class]="triggerClasses()"
       [disabled]="zDisabled()"
+      [attr.aria-label]="ariaLabel()"
+      [attr.aria-labelledby]="ariaLabelledby()"
       [attr.aria-expanded]="isOpen()"
       [attr.aria-haspopup]="'listbox'"
       [attr.data-placeholder]="!zValue() ? '' : null"
@@ -154,6 +156,11 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
   readonly class = input<ClassValue>('');
   readonly zDisabled = input(false, { transform: booleanAttribute });
   readonly zLabel = input<string>('');
+  // Accessible name for the combobox trigger. Consumers set the native `aria-label` /
+  // `aria-labelledby` on <z-select>; we forward them to the inner button so screen readers
+  // announce it (a bare attribute on the host wouldn't reach the combobox role).
+  readonly ariaLabel = input<string | null>(null, { alias: 'aria-label' });
+  readonly ariaLabelledby = input<string | null>(null, { alias: 'aria-labelledby' });
   readonly zMaxLabelCount = input<number>(1);
   readonly zMultiple = input<boolean>(false);
   readonly zPlaceholder = input<string>('Select an option...');


### PR DESCRIPTION
## 📋 Description

## What
`z-select` now forwards a native `aria-label` / `aria-labelledby` set on the
`<z-select>` host onto the inner `role="combobox"` button.

## Why
The accessible name lives on the host element, but assistive tech reads the
name from the element carrying `role="combobox"` — the inner `<button>`. So a
consumer writing `<z-select aria-label="...">` today gets **no** accessible
name on the combobox; screen readers fall back to the placeholder/selected
text and can't announce what the control is for.

Surfaced by a CodeRabbit a11y review on a consuming app (security-question
dropdowns had visible labels not programmatically tied to the select).

## How
- Two aliased inputs, `aria-label` → `ariaLabel` and `aria-labelledby` →
  `ariaLabelledby`. Because they're declared inputs, Angular consumes the
  host attributes (no duplicate name on the host) and we re-emit them on the
  trigger via `[attr.aria-label]` / `[attr.aria-labelledby]`.
- Both default to `null`, so when unset the attributes aren't rendered — no
  change for existing usages.
## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [x] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
