### PR TITLE
fix(dialog): guard undefined zContent to prevent ɵcmp crash on alert/confirm

### DIFF
--- a/v2/ui/dialog/dialog.service.ts
+++ b/v2/ui/dialog/dialog.service.ts
@@ -123,7 +123,12 @@ export class ZardDialogService {
           } as T,
         ),
       );
-    } else if (typeof componentOrTemplateRef !== 'string') {
+    } else if (componentOrTemplateRef != null && typeof componentOrTemplateRef !== 'string') {
+      // A dialog with no `zContent` (e.g. a title/description-only alert or
+      // confirm) has nothing to attach — render header/footer only. Without the
+      // null/undefined guard, `undefined` falls through to the component branch
+      // and `new ComponentPortal(undefined)` crashes in `getComponentDef` while
+      // reading `ɵcmp` off `undefined`.
       const injector = this.createInjector<T, U>(dialogRef, config);
       const contentRef = dialogContainer.attachComponentPortal<T>(
         new ComponentPortal(componentOrTemplateRef, config.zViewContainerRef, injector),


### PR DESCRIPTION
## Problem
`ConfirmDialogService.alert()` / `.confirm()` create dialogs with only `zTitle`/`zDescription` and no `zContent`. In `ZardDialogService.attachDialogContent()`, content was discriminated as `TemplateRef` → template; else-if not a string → **component**. When `zContent` is `undefined`, it fell into the component branch and ran `new ComponentPortal(undefined)`, crashing in `getComponentDef` reading `ɵcmp` off `undefined`:

`ERROR TypeError: Cannot read properties of undefined (reading 'ɵcmp')`

This crashed every title/description-only alert/confirm (e.g. the AMRIT 104 role workspaces' error dialogs).

## Fix
Guard the component branch against `null`/`undefined` so a content-less dialog renders header/footer only:

```diff
- } else if (typeof componentOrTemplateRef !== 'string') {
+ } else if (componentOrTemplateRef != null && typeof componentOrTemplateRef !== 'string') {
```

## Verification
- `ng build` passes.
- Verified at runtime: alert/confirm dialogs now render correctly with a working OK button and dismiss cleanly; no `ɵcmp` crash. Real-component, TemplateRef, and string content paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog rendering to handle empty or missing content more safely.
  * Prevented crashes when a dialog is opened without valid component or template content.
  * Dialogs now fall back more reliably to header/footer-only display when no content is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->