### PR TITLE
fix(ui): block-level accordion items + muted table headers

### DIFF
--- a/v2/ui/accordion/accordion.variants.ts
+++ b/v2/ui/accordion/accordion.variants.ts
@@ -24,7 +24,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 export const accordionVariants = cva('block');
 
-export const accordionItemVariants = cva('border-b');
+export const accordionItemVariants = cva('flex flex-col border-b');
 
 export const accordionTriggerVariants = cva(
   'flex flex-1 w-full items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50'

--- a/v2/ui/table/table.variants.ts
+++ b/v2/ui/table/table.variants.ts
@@ -23,7 +23,7 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 
 export const tableVariants = cva(
-  'w-full caption-bottom text-sm [&_thead_tr]:border-b [&_tbody]:border-0 [&_tbody_tr:last-child]:border-0 [&_tbody_tr]:border-b [&_tbody_tr]:transition-colors [&_tbody_tr]:hover:bg-muted/50 [&_tbody_tr]:data-[state=selected]:bg-muted [&_th]:h-10 [&_th]:px-2 [&_th]:text-left [&_th]:align-middle [&_th]:font-medium [&_th]:text-foreground [&_th:has([role=checkbox])]:pr-0 [&_th>[role=checkbox]]:translate-y-0.5 [&_td]:p-2 [&_td]:align-middle [&_td:has([role=checkbox])]:pr-0 [&_td>[role=checkbox]]:translate-y-0.5 [&_caption]:mt-4 [&_caption]:text-sm [&_caption]:text-muted-foreground',
+  'w-full caption-bottom text-sm [&_thead_tr]:border-b [&_tbody]:border-0 [&_tbody_tr:last-child]:border-0 [&_tbody_tr]:border-b [&_tbody_tr]:transition-colors [&_tbody_tr]:hover:bg-muted/50 [&_tbody_tr]:data-[state=selected]:bg-muted [&_th]:h-10 [&_th]:px-2 [&_th]:text-left [&_th]:align-middle [&_th]:font-medium [&_th]:text-muted-foreground [&_th:has([role=checkbox])]:pr-0 [&_th>[role=checkbox]]:translate-y-0.5 [&_td]:p-2 [&_td]:align-middle [&_td:has([role=checkbox])]:pr-0 [&_td>[role=checkbox]]:translate-y-0.5 [&_caption]:mt-4 [&_caption]:text-sm [&_caption]:text-muted-foreground',
   {
     variants: {
       zType: {


### PR DESCRIPTION
Two small shadcn-fidelity fixes to the shared Zard components, found while reviewing the migrated MMU-UI screens.

## Accordion — collapsed items were too tall
`accordionItemVariants` was `cva('border-b')` with **no `display`**, so `<z-accordion-item>` (a custom element) defaulted to `display: inline`. When a template puts the trigger as a **direct child** (rather than wrapping it in a block `<div>`), the trigger laid out in an inline formatting context and gained line-box leading — producing a tall, mostly-empty collapsed card (measured ~2.4x the height of a correctly-wrapped one).

Fix: `'flex flex-col border-b'` — the item is now a block flex column and its children (trigger + content) are blockified, so collapsed items are exactly the header height. This matches shadcn's `AccordionItem`, which is a block `div`. Verified via DevTools: collapsed item = 52px (button 52 + content 0).

## Table — headers now muted
`th` used `text-foreground` (dark). shadcn's widely-used `TableHead` style is `text-muted-foreground`; switched to muted so headers read lighter and less heavy.

Both are pure styling in `v2/ui`; no API changes. Benefits every consumer of the migration line (MMU-UI, Inventory-UI).