### PR TITLE
fix: registrar revisit 'session expired' and accordion overflow clipping

### DIFF
--- a/v2/registrar/registration/location-information/location-information.component.ts
+++ b/v2/registrar/registration/location-information/location-information.component.ts
@@ -124,9 +124,20 @@ export class LocationInformationComponent {
     const locationData: any = this.sessionstorage.getItem('locationData');
     this.locationDetails = JSON.parse(locationData);
     if (this.patientRevisit) {
-      this.locationInfoFormGroup.patchValue(this.revisitData);
+      // Edit/revisit mode: patch the beneficiary's saved location WITHOUT
+      // emitting, or the cascade valueChanges subscriptions fire onChangeLocation
+      // before the state/district/block/village master lists are loaded — which
+      // throws on `.find(undefined)` and issues location calls with `/undefined`
+      // IDs (401 → "session expired"). The real cascade is loaded below by
+      // loadLocationFromStorage() → loadState → loadDistrict → … using
+      // locationPatchDetails, so these patches only need to seed the form.
+      this.locationInfoFormGroup.patchValue(this.revisitData, {
+        emitEvent: false,
+      });
       this.locationPatchDetails = this.revisitData.i_bendemographics;
-      this.locationInfoFormGroup.patchValue(this.locationPatchDetails);
+      this.locationInfoFormGroup.patchValue(this.locationPatchDetails, {
+        emitEvent: false,
+      });
     }
     this.loadLocationFromStorage();
     console.log('location Form Data', this.formData);

--- a/v2/ui/accordion/accordion.component.ts
+++ b/v2/ui/accordion/accordion.component.ts
@@ -25,6 +25,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
   inject,
   input,
   output,
@@ -170,7 +171,7 @@ export class ZardAccordionTriggerComponent {
   selector: 'z-accordion-content, [z-accordion-content]',
   template: `
     <div
-      class="overflow-hidden"
+      [class]="overflowVisible() ? 'overflow-visible' : 'overflow-hidden'"
       [attr.inert]="open() ? null : ''"
       [attr.aria-hidden]="open() ? null : 'true'">
       <div class="pb-4 pt-0">
@@ -196,6 +197,29 @@ export class ZardAccordionContentComponent {
   readonly class = input<ClassValue>('');
 
   readonly open = computed(() => this.item?.open() ?? false);
+
+  // Panel content is clipped (overflow-hidden) while it expands/collapses so the
+  // grid-rows height animation reveals it cleanly. Once fully open, switch to
+  // overflow-visible a beat later so overlays inside the panel — dropdowns,
+  // autocomplete suggestion lists — aren't cut off by the panel box. Reverts to
+  // hidden immediately on close so the collapse stays clean.
+  protected readonly overflowVisible = signal(false);
+  private overflowTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor() {
+    effect(() => {
+      const isOpen = this.open();
+      clearTimeout(this.overflowTimer);
+      if (isOpen) {
+        this.overflowTimer = setTimeout(
+          () => this.overflowVisible.set(true),
+          220,
+        );
+      } else {
+        this.overflowVisible.set(false);
+      }
+    });
+  }
 
   protected readonly classes = computed(() =>
     mergeClasses(accordionContentVariants(), this.class())


### PR DESCRIPTION
## Summary

Two independent QA fixes surfaced while running the migrated MMU-UI nurse/doctor and
registrar flows against UAT. Kept as separate commits.

## 1. `fix(registrar): seed revisit location without emitting the cascade`

**Symptom:** opening a beneficiary for **edit/revisit** immediately failed with
"session expired" and never rendered the saved location.

**Cause:** in revisit mode the saved location was patched with `emitEvent` enabled, so
the `onChangeLocation` cascade fired *before* the state/district/block/village master
lists had loaded. It hit `.find(undefined)` and issued location calls with `/undefined`
IDs → 401 → "session expired".

**Fix:** patch the revisit data with `{ emitEvent: false }` so it only seeds the form.
The real cascade is driven afterwards by `loadLocationFromStorage()` → `loadState` →
`loadDistrict` → … from `locationPatchDetails`, which run once the master lists exist.

## 2. `fix(ui): reveal accordion overflow once open so nested overlays aren't clipped`

**Symptom:** dropdowns / autocomplete suggestion lists opened **inside** an accordion
panel were cut off by the panel edge.

**Cause:** `z-accordion-content` was permanently `overflow-hidden`.

**Fix:** keep `overflow-hidden` while the panel expands/collapses (so the `grid-rows`
height animation reveals it cleanly), then switch to `overflow-visible` a beat (~220ms)
after it is fully open, and revert to hidden immediately on close. Uses an `effect()` on
the open signal with a timeout that's cleared on every state change.

## Notes
- Base: `angular-zard-migration` (Common-UI's Zard/Tailwind integration branch).
- Consumed by MMU-UI PR PSMRI/MMU-UI#432; the MMU-UI submodule pointer will be bumped to
  the merge commit once this lands.
