### PR TITLE
fix(select): clear active ring when a z-select closes on outside click

### DIFF
--- a/v2/ui/select/select.component.ts
+++ b/v2/ui/select/select.component.ts
@@ -521,8 +521,11 @@ export class ZardSelectComponent implements ControlValueAccessor, OnDestroy {
             takeUntilDestroyed(this.destroyRef),
           )
           .subscribe(() => {
-            this.isFocus.set(false);
+            // Close first: close() runs updateFocusWhenNormalMode() which would set isFocus
+            // back to true (since the dropdown is now closed). Clearing focus AFTER close
+            // ensures a click-away leaves no lingering active (blue) ring on the trigger.
             this.close();
+            this.isFocus.set(false);
           });
       } catch (error) {
         console.error('Error creating overlay:', error);


### PR DESCRIPTION
## Description

A `z-select` keeps its blue **active ring** (`data-active`) after the dropdown is closed by **clicking outside** it — so a control the user has clicked away from still looks focused.

**Root cause:** in the `outsidePointerEvents()` subscription the handler sets `isFocus` to `false` **before** calling `close()`. But `close()` runs `updateFocusWhenNormalMode()`, which sets `isFocus = !isOpen()` — and since the dropdown is now closed, that resolves to `true`. So focus is immediately re-set to `true`, leaving the active ring on the trigger.

**Fix:** call `close()` **first**, then set `isFocus` to `false`, so clearing focus wins and no lingering ring remains. Genuine focus (open → select / keyboard) is unaffected.

## Steps to reproduce
1. Open a `z-select` dropdown.
2. Click another field (outside the select) without picking an option.
3. The `z-select` keeps the blue active ring even though it's no longer focused.

## Change
```diff
   .outsidePointerEvents()
   .subscribe(() => {
-    this.isFocus.set(false);
-    this.close();
+    // close() runs updateFocusWhenNormalMode() which would re-set isFocus to true
+    // (dropdown now closed); clearing focus AFTER close ensures no lingering ring.
+    this.close();
+    this.isFocus.set(false);
   });
```

## Type of Change
- [x] Bug fix (non-breaking)
- [ ] New feature
- [ ] Breaking change

## Notes
Found and verified live while migrating the Helpline1097 CO flow (a returning stale ring after opening a dropdown and clicking another field). Rebased onto the current `angular-zard-migration` tip.