### PR TITLE
fix(registrar): enforce mandatory fields on registration + readable search errors & inline paginator

### DIFF
--- a/v2/registrar/registration/location-information/location-information.component.ts
+++ b/v2/registrar/registration/location-information/location-information.component.ts
@@ -79,26 +79,26 @@ export class LocationInformationComponent {
 
   ngOnInit() {
     this.formData.forEach((item: any) => {
-      if (item.fieldName && item.allowText) {
-        this.locationInfoFormGroup.addControl(
-          item.fieldName,
-          new FormControl(null, [
-            Validators.pattern(this.allowTextValidator(item.allowText)),
-            Validators.minLength(parseInt(item?.allowMin)),
-            Validators.maxLength(parseInt(item?.allowMax)),
-          ]),
-        );
-      } else {
-        this.locationInfoFormGroup.addControl(
-          item.fieldName,
-          new FormControl(null),
-        );
-        // Initialize filtered list with all options
-        if (item.options) {
-          this.filteredOptions[item.fieldName] = [...item.options];
-        }
+      // Attach Validators.required for isRequired fields (migration dropped this;
+      // see personal-information for the full explanation).
+      const validators = [];
+      if (item.isRequired) {
+        validators.push(Validators.required);
       }
-
+      if (item.fieldName && item.allowText) {
+        validators.push(
+          Validators.pattern(this.allowTextValidator(item.allowText)),
+          Validators.minLength(parseInt(item?.allowMin)),
+          Validators.maxLength(parseInt(item?.allowMax))
+        );
+      } else if (item.options) {
+        // Initialize filtered list with all options
+        this.filteredOptions[item.fieldName] = [...item.options];
+      }
+      this.locationInfoFormGroup.addControl(
+        item.fieldName,
+        new FormControl(null, validators)
+      );
     });
     this.locationInfoFormGroup.addControl('stateID', new FormControl());
     this.locationInfoFormGroup.addControl('districtID', new FormControl());

--- a/v2/registrar/registration/other-information/other-information.component.ts
+++ b/v2/registrar/registration/other-information/other-information.component.ts
@@ -81,21 +81,23 @@ export class OtherInformationComponent {
   ngOnInit() {
     console.log('this.otherInfoSubscription', this.otherInfoSubscription);
     this.formData.forEach((item: any) => {
+      // Attach Validators.required for isRequired fields (migration dropped this;
+      // see personal-information for the full explanation).
+      const validators = [];
+      if (item.isRequired) {
+        validators.push(Validators.required);
+      }
       if (item.fieldName && item.allowText) {
-        this.otherInfoFormGroup.addControl(
-          item.fieldName,
-          new FormControl(null, [
-            Validators.pattern(this.allowTextValidator(item.allowText)),
-            Validators.minLength(parseInt(item?.allowMin)),
-            Validators.maxLength(parseInt(item?.allowMax)),
-          ]),
-        );
-      } else {
-        this.otherInfoFormGroup.addControl(
-          item.fieldName,
-          new FormControl(null),
+        validators.push(
+          Validators.pattern(this.allowTextValidator(item.allowText)),
+          Validators.minLength(parseInt(item?.allowMin)),
+          Validators.maxLength(parseInt(item?.allowMax))
         );
       }
+      this.otherInfoFormGroup.addControl(
+        item.fieldName,
+        new FormControl(null, validators)
+      );
     });
     console.log('otherInfoFormGroup Data', this.otherInfoFormGroup);
     if (this.patientRevisit)

--- a/v2/registrar/registration/personal-information/personal-information.component.ts
+++ b/v2/registrar/registration/personal-information/personal-information.component.ts
@@ -104,19 +104,34 @@ export class PersonalInformationComponent {
     this.isEnableES = environment.isEnableES || false;
     this.fetchLanguageResponse();
     this.formData.forEach((item: any) => {
+      // A field flagged isRequired in the registration master config must get
+      // Validators.required. The migration dropped this — the label showed a red *
+      // (zRequired) but no validator was attached to the reactive control, so the
+      // form stayed valid while empty and could be submitted blank.
+      const validators = [];
+      if (item.isRequired) {
+        validators.push(Validators.required);
+      }
       if (item.fieldName && item.allowText) {
-        this.personalInfoFormGroup.addControl(
-          item.fieldName,
-          new FormControl(null, [
-            Validators.pattern(this.allowTextValidator(item.allowText)),
-            Validators.minLength(parseInt(item?.allowMin)),
-            Validators.maxLength(parseInt(item?.allowMax)),
-          ])
+        validators.push(
+          Validators.pattern(this.allowTextValidator(item.allowText)),
+          Validators.minLength(parseInt(item?.allowMin)),
+          Validators.maxLength(parseInt(item?.allowMax))
         );
+      }
+      // age / ageAtMarriage are pre-seeded on the group by the parent (for the
+      // ageAtMarriage cross-field validator). addControl() no-ops on an existing
+      // control, so merge validators onto it instead of silently dropping them.
+      const existing = this.personalInfoFormGroup.get(item.fieldName);
+      if (existing) {
+        if (validators.length) {
+          existing.addValidators(validators);
+          existing.updateValueAndValidity({ emitEvent: false });
+        }
       } else {
         this.personalInfoFormGroup.addControl(
           item.fieldName,
-          new FormControl(null)
+          new FormControl(null, validators)
         );
       }
     });

--- a/v2/registrar/registration/registration.component.ts
+++ b/v2/registrar/registration/registration.component.ts
@@ -172,7 +172,35 @@ export class RegistrationComponent {
     return this.currentStep >= this.enabledStepKeys.length - 1;
   }
 
+  // Map a step key to its backing FormGroup so navigation/submit can check validity.
+  private stepFormGroup(key: string): FormGroup | null {
+    switch (key) {
+      case 'personal':
+        return this.personalInfoFormGroup;
+      case 'location':
+        return this.locationInfoFormGroup;
+      case 'other':
+        return this.otherInfoFormGroup;
+      case 'abha':
+        return this.abhaInfoFormGroup;
+      default:
+        return null;
+    }
+  }
+
   nextStep() {
+    // Block advancing while the current step has unfilled mandatory fields, and
+    // surface the errors (markAllAsTouched) so the required messages render.
+    const group = this.stepFormGroup(this.activeStepKey);
+    if (group && group.invalid) {
+      group.markAllAsTouched();
+      this.confirmationService.alert(
+        this.currentLanguageSet?.alerts?.info?.mandatoryFields ||
+          'Please fill all the mandatory fields',
+        'info'
+      );
+      return;
+    }
     if (this.currentStep < this.enabledStepKeys.length - 1) {
       this.currentStep++;
     }
@@ -335,6 +363,17 @@ export class RegistrationComponent {
 
 
   submitBeneficiaryDetails() {
+    // Defensive guard: the Submit button is disabled while invalid, but never save
+    // a blank/partial beneficiary if it is reached programmatically.
+    if (this.mainForm.invalid) {
+      this.mainForm.markAllAsTouched();
+      this.confirmationService.alert(
+        this.currentLanguageSet?.alerts?.info?.mandatoryFields ||
+          'Please fill all the mandatory fields',
+        'info'
+      );
+      return;
+    }
     console.log('registration data', this.mainForm);
     const newDate = this.dateFormatChange();
     const valueToSend = this.mainForm.value;

--- a/v2/registrar/search/search.component.ts
+++ b/v2/registrar/search/search.component.ts
@@ -376,7 +376,8 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
             if (!beneficiaryList || beneficiaryList.length <= 0) {
               this.resetWorklist();
               this.confirmationService.alert(
-                this.currentLanguageSet.alerts.info.beneficiarynotfound,
+                this.currentLanguageSet?.alerts?.info?.beneficiarynotfound ||
+                  'Beneficiary not found',
                 'info',
               );
             } else {
@@ -395,7 +396,8 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
         );
       } else {
         this.confirmationService.alert(
-          this.currentLanguageSet.alerts.info.phoneDetails,
+          this.currentLanguageSet?.alerts?.info?.phoneDetails ||
+            'Please enter the required search details',
           'info',
         );
       }

--- a/v2/registrar/search/search.component.ts
+++ b/v2/registrar/search/search.component.ts
@@ -178,7 +178,10 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
           this.handleESSearchResponse(response);
         },
         (error: any) => {
-          this.confirmationService.alert(error, 'error');
+          this.confirmationService.alert(
+            error?.error?.errorMessage || error?.message || 'Something went wrong',
+            'error',
+          );
         }
       );
   }
@@ -220,7 +223,10 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
             this.handleESSearchResponse(response);
           },
           (error: any) => {
-            this.confirmationService.alert(error, 'error');
+            this.confirmationService.alert(
+            error?.error?.errorMessage || error?.message || 'Something went wrong',
+            'error',
+          );
           }
         );
     } else {
@@ -381,7 +387,10 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
             console.log('hi', JSON.stringify(beneficiaryList, null, 4));
           },
           (error) => {
-            this.confirmationService.alert(error, 'error');
+            this.confirmationService.alert(
+            error?.error?.errorMessage || error?.message || 'Something went wrong',
+            'error',
+          );
           },
         );
       } else {
@@ -554,7 +563,10 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
           else this.confirmationService.alert(result.status, 'warn');
         },
         (error) => {
-          this.confirmationService.alert(error, 'error');
+          this.confirmationService.alert(
+            error?.error?.errorMessage || error?.message || 'Something went wrong',
+            'error',
+          );
         },
       );
     }
@@ -614,7 +626,10 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
               console.log('ES Advanced Search Result:', JSON.stringify(response, null, 4));
             },
             (error) => {
-              this.confirmationService.alert(error, 'error');
+              this.confirmationService.alert(
+            error?.error?.errorMessage || error?.message || 'Something went wrong',
+            'error',
+          );
             },
           );
       } else {
@@ -639,7 +654,10 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
               console.log(JSON.stringify(beneficiaryList, null, 4));
             },
             (error) => {
-              this.confirmationService.alert(error, 'error');
+              this.confirmationService.alert(
+            error?.error?.errorMessage || error?.message || 'Something went wrong',
+            'error',
+          );
             },
           );
       }

--- a/v2/registrar/search/search.component.ts
+++ b/v2/registrar/search/search.component.ts
@@ -618,7 +618,9 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
                 this.resetWorklist();
                 this.quicksearchTerm = null;
                 this.confirmationService.alert(
-                  this.currentLanguageSet.alerts.info.beneficiaryNotFound,
+                  this.currentLanguageSet?.alerts?.info?.beneficiarynotfound ||
+                    this.currentLanguageSet?.alerts?.info?.beneficiaryNotFound ||
+                    'Beneficiary not found',
                   'info',
                 );
               } else {
@@ -647,7 +649,9 @@ export class SearchComponent implements OnInit, DoCheck, AfterViewChecked, OnDes
                 this.resetWorklist();
                 this.quicksearchTerm = null;
                 this.confirmationService.alert(
-                  this.currentLanguageSet.alerts.info.beneficiaryNotFound,
+                  this.currentLanguageSet?.alerts?.info?.beneficiarynotfound ||
+                    this.currentLanguageSet?.alerts?.info?.beneficiaryNotFound ||
+                    'Beneficiary not found',
                   'info',
                 );
               } else {

--- a/v2/ui/paginator/paginator.component.ts
+++ b/v2/ui/paginator/paginator.component.ts
@@ -71,6 +71,7 @@ import { mergeClasses } from '../utils/merge-classes';
           </div>
         }
         <z-pagination
+          class="mx-0 w-auto justify-end"
           [zPageIndex]="currentPage()"
           [zTotal]="totalPages()"
           (zPageIndexChange)="currentPage.set($event)"></z-pagination>


### PR DESCRIPTION
## What

Two related registrar QA fixes from the Zard/Tailwind migration pass:

### 1. Registration can't be submitted empty (QA: Registration form submitted without any entry, Ben ID generated)
The migration to reactive forms + Zard kept the red-asterisk label (`[zRequired]="item.isRequired"`) but stopped attaching a validator to the control — so `mainForm` stayed **valid while empty**: `Next` advanced and `Submit` (gated on `!mainForm.valid`) stayed enabled, generating a blank beneficiary.

- `personal` / `location` / `other-information`: attach `Validators.required` in the `addControl` loop for every field flagged `isRequired` in the master config, alongside the existing pattern/min/max validators. Pre-seeded controls (`age`/`ageAtMarriage`) get the validator merged on, since `FormGroup.addControl` no-ops when the control already exists.
- `registration`: block `nextStep()` while the active step group is invalid (`markAllAsTouched` to surface the required messages) + a defensive invalid-guard in `submitBeneficiaryDetails()`.

### 2. Search error/empty states (QA: advanced search shows "[object Object]"; rows/pagination misaligned)
- `search`: show `error.error.errorMessage` (and correct `beneficiarynotfound` key casing) instead of rendering the raw object / a blank dialog.
- `paginator`: keep the paginator inline/right-aligned instead of stretched full-width below the rows-per-page selector.

## Testing
- Registrar → Registration: empty `Next`/`Submit` is blocked with a mandatory-fields alert and red required messages; a complete form registers normally; non-required fields (Last Name, Contact No, Spouse, Occupation) may stay empty.
- Registrar → Advanced Search: no-match / error shows a readable message; paginator stays inline.

## Notes
- Reaches MMU-UI via a submodule-pointer bump (separate follow-up).